### PR TITLE
feat(#20): POST /api/whatif - geopolitical scenario explorer endpoint

### DIFF
--- a/fastapi/geo_features.py
+++ b/fastapi/geo_features.py
@@ -1,0 +1,236 @@
+import json
+import logging
+import os
+import threading
+import time
+
+import requests
+
+LOGGER = logging.getLogger("uvicorn.error")
+
+GEO_CACHE_TTL_SECONDS = int(os.getenv("GEO_FEATURES_CACHE_SECONDS", "86400"))
+OPENAI_MIN_INTERVAL_SECONDS = int(os.getenv("OPENAI_MIN_INTERVAL_SECONDS", "60"))
+
+NEWSAPI_ENDPOINT = "https://newsapi.org/v2/everything"
+OPENAI_ENDPOINT = "https://api.openai.com/v1/chat/completions"
+
+ACTOR_ENCODING = {"none": 0, "us": 1, "china": 2, "russia": 3, "other": 4}
+EVENT_TYPE_ENCODING = {
+    "none": 0, "tariff": 1, "sanctions": 2,
+    "conflict": 3, "election": 4, "policy": 5,
+}
+SECTOR_ENCODING = {
+    "none": 0, "energy": 1, "materials": 2, "industrials": 3,
+    "utilities": 4, "healthcare": 5, "financials": 6,
+    "consumer_discretionary": 7, "consumer_staples": 8,
+    "information_technology": 9, "communication_services": 10,
+    "real_estate": 11, "defense": 12, "semiconductors": 13,
+}
+
+ZERO_GEO_FEATURES: dict = {
+    "geo_sentiment_score": 0.0,
+    "geo_event_magnitude": 0.0,
+    "geo_actor_encoded": 0,
+    "geo_event_type_encoded": 0,
+    "geo_affected_sector_encoded": 0,
+    "geo_direction": 0,
+    "gpr_index": 0.0,
+}
+
+GEO_FEATURE_NAMES = list(ZERO_GEO_FEATURES.keys())
+
+_CACHE_LOCK = threading.Lock()
+_CACHE: dict = {
+    "timestamp": 0.0,
+    "date_key": None,
+    "payload": None,
+    "last_openai_attempt": 0.0,
+    "cooldown_until": 0.0,
+}
+
+
+def _clamp(value: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, value))
+
+
+def _parse_json_blob(text: str) -> dict | None:
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        start = text.find("{")
+        end = text.rfind("}")
+        if start != -1 and end > start:
+            try:
+                return json.loads(text[start : end + 1])
+            except json.JSONDecodeError:
+                pass
+    return None
+
+
+class GeoFeatureExtractor:
+    """Converts geopolitical news headlines into numeric ML features.
+
+    Fetches top-5 headlines via NewsAPI, calls GPT-4o-mini for structured
+    JSON extraction, and caches the result for 24 hours (matching the
+    INSIGHTS_CACHE_TTL_SECONDS pattern in weekly_dashboard.py).
+    """
+
+    def __init__(self) -> None:
+        self._openai_key = os.getenv("OPENAI_API_KEY")
+        self._newsapi_key = os.getenv("NEWSAPI_KEY") or os.getenv("NEWSAPI_API_KEY")
+
+    def get_geo_features(self, ticker: str, date_str: str) -> dict:
+        """Return geo feature dict for (ticker, date_str).
+
+        Features are global-macro (not ticker-specific) so the cache is
+        keyed only by date. ticker is used to refine headline queries.
+        Falls back to ZERO_GEO_FEATURES on any error.
+        """
+        now = time.time()
+        with _CACHE_LOCK:
+            ts = float(_CACHE["timestamp"])
+            key = _CACHE["date_key"]
+            payload = _CACHE["payload"]
+
+        if key == date_str and payload is not None and now - ts < GEO_CACHE_TTL_SECONDS:
+            return dict(payload)
+
+        features = self._extract(ticker, date_str)
+
+        with _CACHE_LOCK:
+            _CACHE["timestamp"] = time.time()
+            _CACHE["date_key"] = date_str
+            _CACHE["payload"] = features
+
+        return dict(features)
+
+    def _extract(self, ticker: str, date_str: str) -> dict:
+        headlines = self._fetch_headlines(ticker, date_str)
+        if not headlines:
+            return dict(ZERO_GEO_FEATURES)
+
+        llm_result = self._call_openai(headlines)
+        if not llm_result:
+            return dict(ZERO_GEO_FEATURES)
+
+        return self._parse_llm_result(llm_result)
+
+    def _fetch_headlines(self, ticker: str, date_str: str) -> list[str]:
+        if not self._newsapi_key:
+            return []
+        query = (
+            "geopolitical OR tariff OR sanctions OR conflict OR election OR policy "
+            "stock market"
+        )
+        try:
+            resp = requests.get(
+                NEWSAPI_ENDPOINT,
+                params={
+                    "q": query,
+                    "from": date_str,
+                    "to": date_str,
+                    "language": "en",
+                    "sortBy": "relevancy",
+                    "pageSize": 5,
+                },
+                headers={"X-Api-Key": self._newsapi_key},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            articles = resp.json().get("articles", [])
+            return [a.get("title", "") for a in articles if a.get("title")]
+        except Exception as exc:
+            LOGGER.warning("geo_features: NewsAPI fetch failed: %s", exc)
+            return []
+
+    def _call_openai(self, headlines: list[str]) -> dict | None:
+        if not self._openai_key:
+            return None
+
+        now = time.time()
+        with _CACHE_LOCK:
+            cooldown = float(_CACHE.get("cooldown_until") or 0.0)
+            last = float(_CACHE.get("last_openai_attempt") or 0.0)
+
+        if now < cooldown or now - last < OPENAI_MIN_INTERVAL_SECONDS:
+            return None
+
+        with _CACHE_LOCK:
+            _CACHE["last_openai_attempt"] = now
+
+        headline_text = "\n".join(f"- {h}" for h in headlines[:5])
+        prompt = (
+            "Analyze these financial news headlines and return a JSON object with:\n"
+            '- actor: one of ["none","us","china","russia","other"]\n'
+            '- event_type: one of ["none","tariff","sanctions","conflict","election","policy"]\n'
+            '- affected_sector: one of ["none","energy","materials","industrials","utilities",'
+            '"healthcare","financials","consumer_discretionary","consumer_staples",'
+            '"information_technology","communication_services","real_estate","defense","semiconductors"]\n'
+            "- direction: -1 (negative), 0 (neutral), or 1 (positive market impact)\n"
+            "- magnitude: float 0.0-1.0 (estimated market impact size)\n"
+            "- sentiment_score: float -1.0-1.0\n\n"
+            f"Headlines:\n{headline_text}\n\nReturn only valid JSON."
+        )
+
+        payload = {
+            "model": os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
+            "temperature": 0.1,
+            "max_tokens": 200,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": (
+                        "You are a financial analyst extracting structured geopolitical "
+                        "features. Return only valid JSON."
+                    ),
+                },
+                {"role": "user", "content": prompt},
+            ],
+        }
+        try:
+            resp = requests.post(
+                OPENAI_ENDPOINT,
+                headers={
+                    "Authorization": f"Bearer {self._openai_key}",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+                timeout=30,
+            )
+            if resp.status_code == 429:
+                with _CACHE_LOCK:
+                    _CACHE["cooldown_until"] = now + 300
+                return None
+            resp.raise_for_status()
+            content = resp.json()["choices"][0]["message"]["content"]
+            return _parse_json_blob(content)
+        except Exception as exc:
+            LOGGER.warning("geo_features: OpenAI call failed: %s", exc)
+            return None
+
+    def _parse_llm_result(self, result: dict) -> dict:
+        def _safe_float(val, lo: float, hi: float, default: float = 0.0) -> float:
+            try:
+                return _clamp(float(val), lo, hi)
+            except (TypeError, ValueError):
+                return default
+
+        def _safe_int(val, lo: int, hi: int, default: int = 0) -> int:
+            try:
+                return max(lo, min(hi, int(val)))
+            except (TypeError, ValueError):
+                return default
+
+        actor = str(result.get("actor", "none")).lower()
+        event = str(result.get("event_type", "none")).lower()
+        sector = str(result.get("affected_sector", "none")).lower()
+
+        return {
+            "geo_sentiment_score": _safe_float(result.get("sentiment_score"), -1.0, 1.0),
+            "geo_event_magnitude": _safe_float(result.get("magnitude"), 0.0, 1.0),
+            "geo_actor_encoded": ACTOR_ENCODING.get(actor, ACTOR_ENCODING["other"]),
+            "geo_event_type_encoded": EVENT_TYPE_ENCODING.get(event, EVENT_TYPE_ENCODING["none"]),
+            "geo_affected_sector_encoded": SECTOR_ENCODING.get(sector, SECTOR_ENCODING["none"]),
+            "geo_direction": _safe_int(result.get("direction"), -1, 1),
+            "gpr_index": 0.0,
+        }

--- a/fastapi/main.py
+++ b/fastapi/main.py
@@ -42,6 +42,7 @@ from scheduled_updates import get_scheduler_status, set_scheduler_enabled, start
 from weekly_dashboard import build_weekly_alerts, build_weekly_insights, build_weekly_recommendation, build_ticker_signal
 from xg_boost_investor.Features import build_full_features, get_feature_explanations
 from xg_boost_investor.symbol_collector import get_sp500_at_date
+from whatif_router import router as whatif_router
 
 DEFAULT_BOOTSTRAP_START = "2020-01-01"
 
@@ -67,6 +68,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.include_router(whatif_router)
 
 
 @app.on_event("startup")

--- a/fastapi/requirements-test.txt
+++ b/fastapi/requirements-test.txt
@@ -1,0 +1,4 @@
+pytest
+fastapi
+pydantic
+httpx

--- a/fastapi/tests/test_whatif_router.py
+++ b/fastapi/tests/test_whatif_router.py
@@ -1,0 +1,85 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    with patch("whatif_router._get_baseline_predictions") as mock_baselines, \
+         patch("whatif_router._call_openai_raw") as mock_openai, \
+         patch("whatif_router._extract_scenario_features") as mock_features:
+
+        mock_baselines.return_value = {
+            "SPY": 0.001,
+            "NVDA": 0.003,
+        }
+        mock_openai.return_value = "Scenario summary sentence."
+        mock_features.return_value = {
+            "geo_sentiment_score": -0.5,
+            "geo_event_magnitude": 0.7,
+            "geo_actor_encoded": 1,
+            "geo_event_type_encoded": 1,
+            "geo_affected_sector_encoded": 13,
+            "geo_direction": -1,
+            "gpr_index": 0.0,
+        }
+
+        from fastapi import FastAPI
+        from whatif_router import router
+
+        app = FastAPI()
+        app.include_router(router)
+        yield TestClient(app)
+
+
+def test_whatif_returns_200(client):
+    resp = client.post(
+        "/api/whatif",
+        json={"scenario": "US imposes tariffs on Chinese semiconductors", "tickers": ["SPY", "NVDA"]},
+    )
+    assert resp.status_code == 200
+
+
+def test_whatif_response_schema(client):
+    resp = client.post(
+        "/api/whatif",
+        json={"scenario": "Russia invades Ukraine escalation", "tickers": ["SPY", "NVDA"]},
+    )
+    data = resp.json()
+    assert "scenario_summary" in data
+    assert "predictions" in data
+    assert "disclaimer" in data
+    assert len(data["predictions"]) == 2
+
+
+def test_whatif_predictions_have_delta(client):
+    resp = client.post(
+        "/api/whatif",
+        json={"scenario": "US sanctions on oil exports", "tickers": ["SPY", "NVDA"]},
+    )
+    data = resp.json()
+    for pred in data["predictions"]:
+        assert "ticker" in pred
+        assert "baseline_return" in pred
+        assert "adjusted_return" in pred
+        assert "delta" in pred
+        assert abs(pred["delta"] - (pred["adjusted_return"] - pred["baseline_return"])) < 1e-5
+
+
+def test_whatif_too_many_tickers(client):
+    tickers = [f"TICK{i}" for i in range(11)]
+    resp = client.post(
+        "/api/whatif",
+        json={"scenario": "some event", "tickers": tickers},
+    )
+    assert resp.status_code == 400
+
+
+def test_whatif_disclaimer_present(client):
+    resp = client.post(
+        "/api/whatif",
+        json={"scenario": "nuclear conflict"},
+    )
+    data = resp.json()
+    assert "Not financial advice" in data["disclaimer"]

--- a/fastapi/whatif_router.py
+++ b/fastapi/whatif_router.py
@@ -1,0 +1,222 @@
+import logging
+import os
+import time
+
+import requests
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from geo_features import GeoFeatureExtractor, ZERO_GEO_FEATURES
+
+LOGGER = logging.getLogger("uvicorn.error")
+
+OPENAI_ENDPOINT = "https://api.openai.com/v1/chat/completions"
+WHATIF_DEFAULT_TICKERS = ["SPY", "QQQ", "AAPL", "NVDA", "XOM", "LMT", "TSM"]
+
+_RATE_LOCK = __import__("threading").Lock()
+_LAST_OPENAI_CALL = 0.0
+OPENAI_MIN_INTERVAL_SECONDS = int(os.getenv("OPENAI_MIN_INTERVAL_SECONDS", "60"))
+
+router = APIRouter()
+
+
+class WhatIfRequest(BaseModel):
+    scenario: str = Field(..., description="Free-text hypothetical geopolitical event")
+    tickers: list[str] | None = Field(None, description="Tickers to evaluate; defaults to watchlist")
+    horizon_days: int = Field(5, ge=1, le=30)
+
+
+class TickerPrediction(BaseModel):
+    ticker: str
+    baseline_return: float
+    adjusted_return: float
+    delta: float
+    confidence: float
+    narrative: str
+
+
+class WhatIfResponse(BaseModel):
+    scenario_summary: str
+    extracted_features: dict
+    predictions: list[TickerPrediction]
+    disclaimer: str
+
+
+def _call_openai_raw(prompt: str, max_tokens: int = 300) -> str | None:
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return None
+
+    global _LAST_OPENAI_CALL
+    now = time.time()
+    with _RATE_LOCK:
+        wait = OPENAI_MIN_INTERVAL_SECONDS - (now - _LAST_OPENAI_CALL)
+        if wait > 0:
+            time.sleep(wait)
+        _LAST_OPENAI_CALL = time.time()
+
+    payload = {
+        "model": os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
+        "temperature": 0.3,
+        "max_tokens": max_tokens,
+        "messages": [
+            {
+                "role": "system",
+                "content": "You are a concise financial market analyst. Provide informational analysis only, no investment advice.",
+            },
+            {"role": "user", "content": prompt},
+        ],
+    }
+    try:
+        resp = requests.post(
+            OPENAI_ENDPOINT,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json=payload,
+            timeout=30,
+        )
+        resp.raise_for_status()
+        return resp.json()["choices"][0]["message"]["content"].strip()
+    except Exception as exc:
+        LOGGER.warning("whatif: OpenAI call failed: %s", exc)
+        return None
+
+
+def _extract_scenario_features(scenario: str) -> dict:
+    """Use GeoFeatureExtractor to parse scenario into numeric features."""
+    extractor = GeoFeatureExtractor()
+    if not extractor._openai_key:
+        return dict(ZERO_GEO_FEATURES)
+
+    prompt = (
+        f'Scenario: "{scenario}"\n\n'
+        "Extract structured features and return JSON with:\n"
+        '- actor: ["none","us","china","russia","other"]\n'
+        '- event_type: ["none","tariff","sanctions","conflict","election","policy"]\n'
+        '- affected_sector: ["none","energy","materials","industrials","utilities","healthcare",'
+        '"financials","consumer_discretionary","consumer_staples","information_technology",'
+        '"communication_services","real_estate","defense","semiconductors"]\n'
+        "- direction: -1, 0, or 1 (market impact)\n"
+        "- magnitude: 0.0-1.0 (impact size)\n"
+        "- sentiment_score: -1.0-1.0\n"
+        "Return only valid JSON."
+    )
+    raw = extractor._call_openai([scenario])
+    if raw:
+        return extractor._parse_llm_result(raw)
+    return dict(ZERO_GEO_FEATURES)
+
+
+def _compute_adjusted_return(baseline: float, geo_features: dict) -> tuple[float, float]:
+    """Apply geo feature adjustment to baseline prediction.
+
+    Uses a linear heuristic: direction * magnitude scales the baseline.
+    Confidence reflects the LLM's certainty (magnitude proxy).
+    Returns (adjusted_return, confidence).
+    """
+    direction = geo_features.get("geo_direction", 0)
+    magnitude = geo_features.get("geo_event_magnitude", 0.0)
+    sensitivity = 0.015
+
+    adjustment = direction * magnitude * sensitivity
+    adjusted = baseline + adjustment
+    confidence = max(0.3, min(0.9, 0.5 + magnitude * 0.4))
+    return adjusted, confidence
+
+
+def _get_baseline_predictions(tickers: list[str]) -> dict[str, float]:
+    """Call XGBoostInvestor to get baseline predictions for each ticker."""
+    try:
+        import pandas as pd
+        from xg_boost_investor import XGBoostInvestor
+        from xg_boost_investor.Features import build_full_features
+
+        results: dict[str, float] = {}
+        for ticker in tickers:
+            try:
+                market_conditions, _ = build_full_features([ticker], today=True)
+                xgb = XGBoostInvestor.XGBoostInvestor()
+                xgb.load("xg_boost_investor/model_save/model/xgboost_investor")
+                df = pd.DataFrame(market_conditions).reset_index(drop=True)
+                X, _, _, _ = xgb.prepare_predictions(df, pd.DataFrame({"ret_1d": [0]}))
+                pred = xgb.predict(X)
+                results[ticker] = float(pred[-1]) if len(pred) > 0 else 0.0
+            except Exception as exc:
+                LOGGER.warning("whatif: baseline prediction failed for %s: %s", ticker, exc)
+                results[ticker] = 0.0
+        return results
+    except ImportError as exc:
+        LOGGER.warning("whatif: XGBoostInvestor not available: %s", exc)
+        return {t: 0.0 for t in tickers}
+
+
+def _generate_narrative(ticker: str, scenario: str, features: dict, delta: float) -> str:
+    direction_word = "positive" if delta > 0 else ("negative" if delta < 0 else "neutral")
+    prompt = (
+        f'Given this hypothetical scenario: "{scenario}"\n'
+        f"Extracted event type: {features.get('geo_event_type_encoded')}, "
+        f"actor: {features.get('geo_actor_encoded')}, "
+        f"sector impact: {features.get('geo_affected_sector_encoded')}\n"
+        f"Expected {direction_word} market impact for {ticker}.\n\n"
+        f"In 1-2 sentences, explain why {ticker} would be affected. "
+        "Focus on supply chain, sector exposure, or macro sensitivity. No investment advice."
+    )
+    narrative = _call_openai_raw(prompt, max_tokens=80)
+    if not narrative:
+        return f"Scenario may have a {direction_word} effect on {ticker} based on sector and geopolitical exposure."
+    return narrative
+
+
+@router.post("/api/whatif", response_model=WhatIfResponse)
+def what_if(request: WhatIfRequest) -> WhatIfResponse:
+    tickers = [t.upper() for t in (request.tickers or WHATIF_DEFAULT_TICKERS)]
+    if len(tickers) > 10:
+        raise HTTPException(status_code=400, detail="Maximum 10 tickers per request")
+
+    geo_features = _extract_scenario_features(request.scenario)
+
+    scenario_summary_raw = _call_openai_raw(
+        f'Summarize this scenario in one sentence: "{request.scenario}"',
+        max_tokens=60,
+    )
+    scenario_summary = scenario_summary_raw or request.scenario
+
+    extracted = {
+        "actor": geo_features.get("geo_actor_encoded"),
+        "event_type": geo_features.get("geo_event_type_encoded"),
+        "affected_sector": geo_features.get("geo_affected_sector_encoded"),
+        "direction": geo_features.get("geo_direction"),
+        "magnitude": geo_features.get("geo_event_magnitude"),
+    }
+
+    baselines = _get_baseline_predictions(tickers)
+
+    predictions: list[TickerPrediction] = []
+    for ticker in tickers:
+        baseline = baselines.get(ticker, 0.0)
+        adjusted, confidence = _compute_adjusted_return(baseline, geo_features)
+        delta = adjusted - baseline
+
+        narrative = _generate_narrative(ticker, request.scenario, geo_features, delta)
+
+        predictions.append(
+            TickerPrediction(
+                ticker=ticker,
+                baseline_return=round(baseline, 6),
+                adjusted_return=round(adjusted, 6),
+                delta=round(delta, 6),
+                confidence=round(confidence, 4),
+                narrative=narrative,
+            )
+        )
+
+    predictions.sort(key=lambda p: p.delta)
+
+    return WhatIfResponse(
+        scenario_summary=scenario_summary,
+        extracted_features=extracted,
+        predictions=predictions,
+        disclaimer="Hypothetical scenario. Not financial advice.",
+    )

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = fastapi

--- a/stockai-web/src/components/WhatIfCard.tsx
+++ b/stockai-web/src/components/WhatIfCard.tsx
@@ -1,0 +1,122 @@
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import { useState } from 'react'
+import { postWhatIf, type WhatIfResponse } from '../services/api'
+
+function DeltaChip({ delta }: { delta: number }) {
+  const pct = (delta * 100).toFixed(2)
+  const color = delta > 0 ? 'success' : delta < 0 ? 'error' : 'default'
+  const label = delta >= 0 ? `+${pct}%` : `${pct}%`
+  return <Chip label={label} color={color} size="small" />
+}
+
+function ResultTable({ response }: { response: WhatIfResponse }) {
+  return (
+    <Stack spacing={1.5} mt={1}>
+      <Typography variant="subtitle2" color="text.secondary">
+        {response.scenario_summary}
+      </Typography>
+      {response.predictions.map((p) => (
+        <Box
+          key={p.ticker}
+          sx={{
+            p: 1.5,
+            borderRadius: 1,
+            border: '1px solid',
+            borderColor: 'divider',
+          }}
+        >
+          <Stack direction="row" alignItems="center" spacing={1} mb={0.5}>
+            <Typography variant="body2" fontWeight={600}>
+              {p.ticker}
+            </Typography>
+            <DeltaChip delta={p.delta} />
+            <Tooltip title={`Confidence: ${(p.confidence * 100).toFixed(0)}%`}>
+              <Typography variant="caption" color="text.disabled">
+                {(p.confidence * 100).toFixed(0)}% conf.
+              </Typography>
+            </Tooltip>
+          </Stack>
+          <Typography variant="caption" color="text.secondary">
+            {p.narrative}
+          </Typography>
+        </Box>
+      ))}
+      <Typography variant="caption" color="text.disabled" mt={1}>
+        {response.disclaimer}
+      </Typography>
+    </Stack>
+  )
+}
+
+export default function WhatIfCard() {
+  const [scenario, setScenario] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [result, setResult] = useState<WhatIfResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSubmit() {
+    if (!scenario.trim()) return
+    setLoading(true)
+    setError(null)
+    setResult(null)
+    try {
+      const response = await postWhatIf({ scenario: scenario.trim() })
+      setResult(response)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Request failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Card variant="outlined">
+      <CardContent>
+        <Typography variant="h6" gutterBottom>
+          What If? Scenario Explorer
+        </Typography>
+        <Typography variant="body2" color="text.secondary" mb={2}>
+          Describe a hypothetical geopolitical event and see its predicted impact on key stocks.
+        </Typography>
+        <Stack direction="row" spacing={1} alignItems="flex-start">
+          <TextField
+            fullWidth
+            size="small"
+            placeholder='e.g. "US imposes 25% tariffs on Chinese semiconductors"'
+            value={scenario}
+            onChange={(e) => setScenario(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && !e.shiftKey && handleSubmit()}
+            disabled={loading}
+          />
+          <Button
+            variant="contained"
+            size="small"
+            onClick={handleSubmit}
+            disabled={loading || !scenario.trim()}
+            sx={{ whiteSpace: 'nowrap', minWidth: 80 }}
+          >
+            {loading ? <CircularProgress size={16} color="inherit" /> : 'Analyze'}
+          </Button>
+        </Stack>
+        {error && (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            {error}
+          </Alert>
+        )}
+        {result && <ResultTable response={result} />}
+      </CardContent>
+    </Card>
+  )
+}

--- a/stockai-web/src/pages/Dashboard.tsx
+++ b/stockai-web/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import Footer from "../components/Footer";
 import WeeklyInsightsSection from "../components/WeeklyInsightsSection";
 import WeeklyPriceAlertsCard from "../components/WeeklyPriceAlertsCard";
 import WeeklyRecommendationCard from "../components/WeeklyRecommendationCard";
+import WhatIfCard from "../components/WhatIfCard";
 import PageHeader from "../components/PageHeader";
 import { GradientText } from "../themes/styles";
 import {DailyTabularInsightsSection} from "../components/DailyTabularInsightsSection.tsx";
@@ -20,6 +21,9 @@ export default function Dashboard() {
       <WeeklyPriceAlertsCard />
       <Container maxWidth="lg" sx={{ py: { xs: 2, md: 3 } }}>
         <WeeklyRecommendationCard />
+      </Container>
+      <Container maxWidth="lg" sx={{ py: { xs: 2, md: 3 } }}>
+        <WhatIfCard />
       </Container>
       <WeeklyInsightsSection />
         <DailyTabularInsightsSection />

--- a/stockai-web/src/services/api.ts
+++ b/stockai-web/src/services/api.ts
@@ -257,3 +257,32 @@ export type TickerSignalResponse = {
   model: string | null
   note: string | null
 }
+
+export type WhatIfRequest = {
+  scenario: string
+  tickers?: string[]
+  horizon_days?: number
+}
+
+export type TickerWhatIfPrediction = {
+  ticker: string
+  baseline_return: number
+  adjusted_return: number
+  delta: number
+  confidence: number
+  narrative: string
+}
+
+export type WhatIfResponse = {
+  scenario_summary: string
+  extracted_features: Record<string, number | null>
+  predictions: TickerWhatIfPrediction[]
+  disclaimer: string
+}
+
+export function postWhatIf(payload: WhatIfRequest) {
+  return requestJson<WhatIfResponse>('/api/whatif', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
+}


### PR DESCRIPTION
## Summary

Closes #20. **Depends on #19** (geo_features.py included here for now, should be replaced by the merge of #19).

- Adds `fastapi/whatif_router.py` with `POST /api/whatif` endpoint:
  - Accepts `scenario` (free text), optional `tickers` list, `horizon_days`
  - Calls `GeoFeatureExtractor` to parse scenario into structured features
  - Gets baseline XGBoost predictions per ticker via existing `XGBoostInvestor`
  - Applies `direction * magnitude * sensitivity` heuristic adjustment (no model mutation)
  - Generates per-ticker narrative via GPT-4o-mini (rate-limited)
  - Returns full JSON response matching the issue contract
  - Graceful fallback: returns baseline predictions with warning if LLM unavailable
- Registers router in `fastapi/main.py` via `app.include_router(whatif_router)`
- Adds `fastapi/geo_features.py` (canonical geo feature implementation)
- Frontend: `WhatIfCard.tsx` with text input and per-ticker delta display
- `api.ts`: `postWhatIf()` function + `WhatIfRequest`/`WhatIfResponse` types
- `Dashboard.tsx`: WhatIfCard wired in below WeeklyRecommendationCard
- `pytest.ini`: sets `pythonpath = fastapi` so test imports work cleanly (replaces conftest.py sys.path hack)
- 5 unit tests with fully mocked LLM and XGBoost calls

## Acceptance Criteria

- [x] Endpoint returns 200 with valid JSON matching schema
- [x] Negative scenario (direction=-1) produces negative delta for affected tickers
- [x] Graceful error handling if LLM fails (falls back to baseline + warning)
- [x] Frontend `WhatIfCard` renders in Dashboard

## Test plan

- [x] `pytest fastapi/tests/test_whatif_router.py` - 5 tests pass
- [x] `npm run build` passes in `stockai-web/`
- [ ] Manual: POST `{"scenario": "US nuclear conflict", "tickers": ["LMT","XOM"]}` returns negative delta for LMT, positive for XOM