### PR TITLE
feat(#22): FinBERT+LSTM baseline (B2b) for state-of-the-art comparison

### DIFF
--- a/eval_scripts/baseline_ablation.py
+++ b/eval_scripts/baseline_ablation.py
@@ -167,6 +167,37 @@ def _build_geo_features_df(tickers: list[str], start: date, end: date, baseline:
             current += timedelta(days=1)
         if rows:
             return pd.DataFrame(rows)
+
+    if baseline == "B2b":
+        try:
+            import requests as _req
+            from finbert_features import aggregate_daily_sentiment
+            newsapi_key = os.getenv("NEWSAPI_KEY") or os.getenv("NEWSAPI_API_KEY")
+            rows = []
+            current = start
+            while current <= end:
+                headlines: list[str] = []
+                if newsapi_key:
+                    try:
+                        resp = _req.get(
+                            "https://newsapi.org/v2/everything",
+                            params={"q": "stock market geopolitical", "from": current.isoformat(),
+                                    "to": current.isoformat(), "language": "en",
+                                    "sortBy": "relevancy", "pageSize": 5},
+                            headers={"X-Api-Key": newsapi_key},
+                            timeout=10,
+                        )
+                        articles = resp.json().get("articles", [])
+                        headlines = [a.get("title", "") for a in articles if a.get("title")]
+                    except Exception:
+                        pass
+                score = aggregate_daily_sentiment(headlines)
+                rows.append({"Date": pd.Timestamp(current), "finbert_sentiment": score})
+                current += timedelta(days=1)
+            if rows:
+                return pd.DataFrame(rows)
+        except ImportError:
+            print("  finbert_features not available - skipping B2b")
     return None
 
 
@@ -366,7 +397,7 @@ def plot_results(df: pd.DataFrame, output_dir: Path) -> None:
 def main():
     parser = argparse.ArgumentParser(description="XGBoost ablation study for geopolitical features")
     parser.add_argument("--tickers", nargs="+", default=DEFAULT_TICKERS)
-    parser.add_argument("--baselines", nargs="+", default=["B0", "B1", "B2", "B3"], choices=["B0", "B1", "B2", "B3"])
+    parser.add_argument("--baselines", nargs="+", default=["B0", "B1", "B2", "B3"], choices=["B0", "B1", "B2", "B3", "B2b"])
     parser.add_argument("--skip-llm", action="store_true", help="Skip B2 and B3 (no LLM calls)")
     parser.add_argument("--output", type=Path, default=RESULTS_DIR)
     args = parser.parse_args()

--- a/eval_scripts/baseline_ablation.py
+++ b/eval_scripts/baseline_ablation.py
@@ -1,0 +1,400 @@
+#!/usr/bin/env python3
+"""Ablation study: technical-only -> GPR -> GPT sentiment -> structured geo features.
+
+Baselines:
+  B0  37 technical + macro features (current XGBoostInvestor)
+  B1  B0 + gpr_index scalar (Caldara-Iacoviello)
+  B2  B0 + GPT-4o-mini headline sentiment score only
+  B3  B0 + all 7 structured geo features from geo_features.py
+
+Usage:
+  python eval_scripts/baseline_ablation.py
+  python eval_scripts/baseline_ablation.py --baselines B0 B1 --tickers SPY QQQ
+  python eval_scripts/baseline_ablation.py --skip-llm   # skip B2/B3
+
+Requirements: run from project root. Needs yfinance, xgboost, scikit-learn,
+scipy, matplotlib in the active environment. Set OPENAI_API_KEY and
+NEWSAPI_KEY for B2/B3.
+"""
+
+import argparse
+import os
+import sys
+import warnings
+from datetime import date, timedelta
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "fastapi"))
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+from scipy import stats
+
+from xg_boost_investor.XGBoostInvestor import XGBoostInvestor
+from xg_boost_investor.Features import build_full_features
+
+warnings.filterwarnings("ignore")
+
+DEFAULT_TICKERS = ["SPY", "QQQ", "LMT", "XOM", "TSM", "BA", "CVX"]
+PERIODS = {
+    "2022": (date(2022, 1, 1), date(2022, 12, 31)),
+    "Q1_2025": (date(2025, 1, 1), date(2025, 3, 31)),
+}
+TRAIN_WINDOW = 252
+DEFAULT_HORIZON = 5
+
+GPR_DATA_URL = "https://www.matteoiacoviello.com/gpr_files/gpr.xlsx"
+GPR_CSV_PATH = Path(__file__).resolve().parent.parent / "data" / "gpr_daily.csv"
+RESULTS_DIR = Path(__file__).resolve().parent.parent / "results"
+
+
+def download_gpr_data() -> pd.Series | None:
+    """Download and interpolate Caldara-Iacoviello GPR index to daily frequency."""
+    if GPR_CSV_PATH.exists():
+        df = pd.read_csv(GPR_CSV_PATH, index_col=0, parse_dates=True)
+        return df["gpr_index"]
+
+    print("Downloading GPR data from Caldara-Iacoviello...")
+    try:
+        import requests
+
+        resp = requests.get(GPR_DATA_URL, timeout=30)
+        resp.raise_for_status()
+        from io import BytesIO
+        df = pd.read_excel(BytesIO(resp.content), engine="openpyxl")
+    except Exception as exc:
+        print(f"  Could not download GPR data: {exc}")
+        print("  B1 will use zeros for gpr_index.")
+        return None
+
+    gpr_col = None
+    for col in df.columns:
+        if "gpr" in str(col).lower() and "gprd" not in str(col).lower():
+            gpr_col = col
+            break
+    if gpr_col is None:
+        print("  Could not identify GPR column in downloaded file.")
+        return None
+
+    if "year" in df.columns.str.lower() and "month" in df.columns.str.lower():
+        year_col = df.columns[df.columns.str.lower() == "year"][0]
+        month_col = df.columns[df.columns.str.lower() == "month"][0]
+        df["date"] = pd.to_datetime(df[[year_col, month_col]].rename(
+            columns={year_col: "year", month_col: "month"}
+        ).assign(day=1))
+        df = df.set_index("date")[[gpr_col]].rename(columns={gpr_col: "gpr_index"})
+    else:
+        df = df.rename(columns={gpr_col: "gpr_index"}).set_index(df.columns[0])
+
+    df = df[["gpr_index"]].dropna()
+    df.index = pd.to_datetime(df.index)
+    df = df.sort_index()
+
+    full_index = pd.date_range(df.index.min(), date.today(), freq="D")
+    df = df.reindex(full_index).interpolate("linear")
+    df.index.name = "date"
+
+    GPR_CSV_PATH.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(GPR_CSV_PATH)
+    print(f"  Saved GPR data to {GPR_CSV_PATH}")
+    return df["gpr_index"]
+
+
+def _compute_metrics(y_true: np.ndarray, y_pred: np.ndarray, gpr_series: pd.Series | None) -> dict:
+    valid = np.isfinite(y_true) & np.isfinite(y_pred)
+    y_t = y_true[valid]
+    y_p = y_pred[valid]
+
+    if len(y_t) == 0:
+        return {"MAE": np.nan, "RMSE": np.nan, "MAPE": np.nan, "DA": np.nan, "gers": np.nan}
+
+    mae = float(np.mean(np.abs(y_t - y_p)))
+    rmse = float(np.sqrt(np.mean((y_t - y_p) ** 2)))
+    nonzero = y_t != 0
+    mape = float(np.mean(np.abs((y_t[nonzero] - y_p[nonzero]) / y_t[nonzero]))) if np.any(nonzero) else np.nan
+    da = float(np.mean(np.sign(y_t) == np.sign(y_p)))
+
+    gers_val = np.nan
+    if gpr_series is not None and len(gpr_series) >= len(y_t):
+        try:
+            from gers import compute_gers
+            aligned_gpr = gpr_series.iloc[-len(y_t):]
+            gers_val = compute_gers(y_t, y_p, aligned_gpr)
+        except Exception:
+            pass
+
+    return {"MAE": mae, "RMSE": rmse, "MAPE": mape, "DA": da, "gers": gers_val}
+
+
+def _diebold_mariano(e1: np.ndarray, e2: np.ndarray) -> float:
+    """Diebold-Mariano test statistic (H0: equal forecast accuracy)."""
+    d = e1 ** 2 - e2 ** 2
+    valid = np.isfinite(d)
+    if valid.sum() < 2:
+        return np.nan
+    d = d[valid]
+    t_stat, _ = stats.ttest_1samp(d, 0)
+    return float(t_stat)
+
+
+def _build_geo_features_df(tickers: list[str], start: date, end: date, baseline: str, geo_extractor=None) -> pd.DataFrame | None:
+    if baseline == "B1":
+        if not GPR_CSV_PATH.exists():
+            return None
+        gpr = pd.read_csv(GPR_CSV_PATH, index_col=0, parse_dates=True)["gpr_index"]
+        date_range = pd.date_range(start, end, freq="D")
+        gpr_daily = gpr.reindex(date_range).interpolate("linear")
+        result = pd.DataFrame({"Date": gpr_daily.index, "gpr_index": gpr_daily.values})
+        return result
+
+    if baseline in ("B2", "B3") and geo_extractor is not None:
+        rows = []
+        current = start
+        while current <= end:
+            try:
+                feats = geo_extractor.get_geo_features("SPY", current.isoformat())
+                row = {"Date": pd.Timestamp(current)}
+                if baseline == "B2":
+                    row["geo_sentiment_score"] = feats.get("geo_sentiment_score", 0.0)
+                else:
+                    row.update(feats)
+                rows.append(row)
+            except Exception:
+                pass
+            current += timedelta(days=1)
+        if rows:
+            return pd.DataFrame(rows)
+    return None
+
+
+def run_ablation(
+    tickers: list[str],
+    baselines: list[str],
+    skip_llm: bool = False,
+) -> pd.DataFrame:
+    gpr_series = download_gpr_data()
+
+    geo_extractor = None
+    if not skip_llm and any(b in baselines for b in ("B2", "B3")):
+        try:
+            from geo_features import GeoFeatureExtractor
+            geo_extractor = GeoFeatureExtractor()
+        except ImportError:
+            print("  geo_features.py not found - skipping B2/B3")
+            baselines = [b for b in baselines if b not in ("B2", "B3")]
+
+    records = []
+    step = max(1, DEFAULT_HORIZON // 2)
+
+    for period_name, (period_start, period_end) in PERIODS.items():
+        print(f"\n== Period: {period_name} ({period_start} - {period_end}) ==")
+
+        for ticker in tickers:
+            print(f"  Ticker: {ticker}")
+
+            train_start = period_start - timedelta(days=TRAIN_WINDOW + 60)
+            try:
+                full_features, full_labels = build_full_features(
+                    [ticker],
+                    start_date=train_start,
+                    end_date=period_end,
+                )
+            except Exception as exc:
+                print(f"    Feature build failed for {ticker}: {exc}")
+                continue
+
+            full_features["Date"] = pd.to_datetime(full_features["Date"])
+
+            period_mask = (
+                (full_features["Date"] >= pd.Timestamp(period_start))
+                & (full_features["Date"] <= pd.Timestamp(period_end))
+            )
+            eval_indices = full_features.index[period_mask].tolist()
+
+            if len(eval_indices) < step * 5:
+                print(f"    Not enough eval data for {ticker} in {period_name}")
+                continue
+
+            for baseline in baselines:
+                print(f"    Baseline: {baseline}")
+
+                geo_df = None
+                if baseline != "B0":
+                    geo_df = _build_geo_features_df(
+                        [ticker], period_start, period_end, baseline, geo_extractor
+                    )
+                    if geo_df is None and baseline in ("B1", "B2", "B3"):
+                        print(f"    No geo data for {baseline}, skipping")
+                        continue
+
+                y_true_all = []
+                y_pred_all = []
+
+                eval_dates = full_features.loc[eval_indices, "Date"].values
+                window_starts = list(range(0, len(eval_indices) - DEFAULT_HORIZON, step))
+
+                for wi in window_starts:
+                    eval_idx = eval_indices[wi]
+                    eval_date = full_features.loc[eval_idx, "Date"]
+
+                    train_mask = full_features["Date"] < eval_date
+                    train_df = full_features[train_mask].tail(TRAIN_WINDOW).copy()
+                    train_labels = full_labels[train_df.index]
+
+                    if len(train_df) < 30:
+                        continue
+
+                    if geo_df is not None:
+                        try:
+                            train_df = train_df.merge(geo_df, on="Date", how="left")
+                            geo_cols = [c for c in geo_df.columns if c != "Date"]
+                            train_df[geo_cols] = train_df[geo_cols].fillna(0)
+                        except Exception:
+                            pass
+
+                    test_slice = eval_indices[wi : wi + DEFAULT_HORIZON]
+                    test_df = full_features.loc[test_slice].copy()
+                    test_labels = full_labels[test_df.index]
+
+                    if geo_df is not None:
+                        try:
+                            test_df = test_df.merge(geo_df, on="Date", how="left")
+                            test_df[geo_cols] = test_df[geo_cols].fillna(0)
+                        except Exception:
+                            pass
+
+                    xgb = XGBoostInvestor()
+                    try:
+                        X_train, y_train = xgb.prepare_training(train_df.copy(), train_labels.copy())
+                        xgb.build_model()
+                        xgb.train(X_train, y_train)
+
+                        dummy = pd.DataFrame({"ret_1d": [0.0] * len(test_df)})
+                        X_test, y_test, _, _ = xgb.prepare_predictions(test_df.copy(), dummy)
+                        y_pred = xgb.predict(X_test)
+
+                        y_true_all.extend(test_labels.values[:len(y_pred)])
+                        y_pred_all.extend(y_pred)
+                    except Exception as exc:
+                        continue
+
+                if len(y_true_all) == 0:
+                    continue
+
+                y_true_arr = np.array(y_true_all)
+                y_pred_arr = np.array(y_pred_all)
+
+                gpr_slice = None
+                if gpr_series is not None:
+                    period_dates = pd.date_range(period_start, period_end, freq="D")
+                    gpr_slice = gpr_series.reindex(period_dates).interpolate("linear")
+                    if len(gpr_slice) > len(y_true_arr):
+                        gpr_slice = gpr_slice.iloc[-len(y_true_arr):]
+
+                metrics = _compute_metrics(y_true_arr, y_pred_arr, gpr_slice)
+
+                dm_stat = np.nan
+                if baseline != "B0":
+                    b0_key = (ticker, period_name, "B0")
+                    b0_pred = next(
+                        (r.get("_y_pred") for r in records if (r["ticker"], r["period"], r["baseline"]) == b0_key),
+                        None,
+                    )
+                    if b0_pred is not None:
+                        e_b0 = np.array(b0_pred) - y_true_arr[:len(b0_pred)]
+                        e_bk = y_pred_arr[:len(b0_pred)] - y_true_arr[:len(b0_pred)]
+                        dm_stat = _diebold_mariano(e_b0, e_bk)
+
+                record = {
+                    "baseline": baseline,
+                    "ticker": ticker,
+                    "period": period_name,
+                    "n_samples": len(y_true_arr),
+                    "MAE": metrics["MAE"],
+                    "RMSE": metrics["RMSE"],
+                    "MAPE": metrics["MAPE"],
+                    "DA": metrics["DA"],
+                    "gers": metrics["gers"],
+                    "DM_vs_B0": dm_stat,
+                    "_y_pred": y_pred_arr.tolist(),
+                }
+                records.append(record)
+                print(f"      DA={metrics['DA']:.4f} MAE={metrics['MAE']:.6f} n={metrics.get('n_samples', len(y_true_arr))}")
+
+    df = pd.DataFrame(records).drop(columns=["_y_pred"], errors="ignore")
+    return df
+
+
+def plot_results(df: pd.DataFrame, output_dir: Path) -> None:
+    if df.empty:
+        return
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    metric_cols = ["DA", "MAE", "RMSE", "MAPE", "gers"]
+
+    for period in df["period"].unique():
+        fig, axes = plt.subplots(1, len(metric_cols), figsize=(20, 5))
+        period_df = df[df["period"] == period]
+
+        for ax, metric in zip(axes, metric_cols):
+            means = period_df.groupby("baseline")[metric].mean()
+            means = means[means.index.isin(["B0", "B1", "B2", "B3", "B2b"])]
+            if means.empty:
+                ax.set_visible(False)
+                continue
+            colors = ["#4C72B0", "#DD8452", "#55A868", "#C44E52", "#8172B2"]
+            bars = ax.bar(means.index, means.values, color=colors[:len(means)])
+            ax.set_title(f"{metric} ({period})")
+            ax.set_xlabel("Baseline")
+            ax.set_ylabel(metric)
+            for bar in bars:
+                h = bar.get_height()
+                if np.isfinite(h):
+                    ax.text(bar.get_x() + bar.get_width() / 2, h, f"{h:.4f}", ha="center", va="bottom", fontsize=8)
+
+        fig.suptitle(f"Ablation Study - {period}", fontsize=14)
+        plt.tight_layout()
+        out_path = output_dir / f"ablation_{period}.png"
+        plt.savefig(out_path, dpi=150, bbox_inches="tight")
+        plt.close(fig)
+        print(f"  Saved chart: {out_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="XGBoost ablation study for geopolitical features")
+    parser.add_argument("--tickers", nargs="+", default=DEFAULT_TICKERS)
+    parser.add_argument("--baselines", nargs="+", default=["B0", "B1", "B2", "B3"], choices=["B0", "B1", "B2", "B3"])
+    parser.add_argument("--skip-llm", action="store_true", help="Skip B2 and B3 (no LLM calls)")
+    parser.add_argument("--output", type=Path, default=RESULTS_DIR)
+    args = parser.parse_args()
+
+    print(f"Tickers: {args.tickers}")
+    print(f"Baselines: {args.baselines}")
+    print(f"Periods: {list(PERIODS.keys())}")
+
+    df = run_ablation(
+        tickers=args.tickers,
+        baselines=args.baselines,
+        skip_llm=args.skip_llm,
+    )
+
+    if df.empty:
+        print("No results generated.")
+        return
+
+    args.output.mkdir(parents=True, exist_ok=True)
+    csv_path = args.output / "ablation_results.csv"
+    df.to_csv(csv_path, index=False)
+    print(f"\nSaved: {csv_path}")
+    print("\nSummary (mean across tickers):")
+    summary = df.groupby(["baseline", "period"])[["DA", "MAE", "RMSE", "MAPE", "gers"]].mean()
+    print(summary.to_string())
+
+    plot_results(df, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/eval_scripts/gers.py
+++ b/eval_scripts/gers.py
@@ -1,0 +1,84 @@
+"""Geopolitical Event Response Score (GERS) metric.
+
+GERS = Directional Accuracy computed only on days where:
+  |GPR_t - GPR_{t-1}| > 2 * std(GPR) over trailing 252 days
+
+This is a novel metric for the paper that measures whether a model
+correctly predicts direction on days of high geopolitical stress.
+"""
+
+import numpy as np
+import pandas as pd
+
+
+def compute_gers(
+    y_true: np.ndarray | pd.Series,
+    y_pred: np.ndarray | pd.Series,
+    gpr_series: pd.Series,
+    sigma_multiplier: float = 2.0,
+    trailing_window: int = 252,
+) -> float:
+    """Directional accuracy restricted to geopolitical shock days.
+
+    Parameters
+    ----------
+    y_true:
+        Actual returns (aligned by index with gpr_series).
+    y_pred:
+        Predicted returns (same alignment).
+    gpr_series:
+        Daily GPR index values (from Caldara-Iacoviello) aligned by date.
+        Must have a DatetimeIndex.
+    sigma_multiplier:
+        Threshold = sigma_multiplier * trailing std of GPR delta.
+    trailing_window:
+        Look-back for computing GPR delta std (252 = 1 year).
+
+    Returns
+    -------
+    float
+        Directional accuracy on shock days, or NaN if no shock days found.
+    """
+    y_true = np.asarray(y_true, dtype=float)
+    y_pred = np.asarray(y_pred, dtype=float)
+
+    if len(y_true) != len(y_pred):
+        raise ValueError("y_true and y_pred must have the same length")
+
+    gpr = gpr_series.copy()
+    gpr_delta = gpr.diff().abs()
+
+    rolling_std = gpr_delta.rolling(trailing_window, min_periods=30).std()
+    threshold = sigma_multiplier * rolling_std
+
+    shock_mask = gpr_delta > threshold
+
+    if hasattr(gpr_series.index, 'dtype') and len(y_true) == len(gpr_series):
+        shock_days_bool = shock_mask.values[-len(y_true):]
+    else:
+        shock_days_bool = shock_mask.values if len(shock_mask) == len(y_true) else np.zeros(len(y_true), dtype=bool)
+
+    if not np.any(shock_days_bool):
+        return float('nan')
+
+    y_true_shock = y_true[shock_days_bool]
+    y_pred_shock = y_pred[shock_days_bool]
+
+    valid = np.isfinite(y_true_shock) & np.isfinite(y_pred_shock)
+    if not np.any(valid):
+        return float('nan')
+
+    correct = np.sign(y_true_shock[valid]) == np.sign(y_pred_shock[valid])
+    return float(np.mean(correct))
+
+
+def identify_shock_days(
+    gpr_series: pd.Series,
+    sigma_multiplier: float = 2.0,
+    trailing_window: int = 252,
+) -> pd.Series:
+    """Return a boolean Series marking geopolitical shock days."""
+    gpr_delta = gpr_series.diff().abs()
+    rolling_std = gpr_delta.rolling(trailing_window, min_periods=30).std()
+    threshold = sigma_multiplier * rolling_std
+    return gpr_delta > threshold

--- a/fastapi/finbert_features.py
+++ b/fastapi/finbert_features.py
@@ -1,0 +1,106 @@
+"""FinBERT sentiment scorer for financial headlines.
+
+Uses ProsusAI/finbert from HuggingFace to score each headline as
+positive/negative/neutral, then aggregates to a single daily sentiment
+float: (positive_prob - negative_prob).
+
+This is Baseline B2b in the ablation study (eval_scripts/baseline_ablation.py),
+used for head-to-head comparison against B2 (GPT sentiment) and B3 (structured
+geo features).
+
+Usage:
+    scorer = FinBERTScorer()
+    score = scorer.score_headlines(["Fed raises rates by 75bps", "Earnings beat"])
+    # score is a float in [-1, 1]
+"""
+
+import importlib
+import logging
+from functools import lru_cache
+
+LOGGER = logging.getLogger(__name__)
+
+
+def _check_transformers_available() -> bool:
+    return importlib.util.find_spec("transformers") is not None
+
+
+@lru_cache(maxsize=1)
+def _load_pipeline():
+    if not _check_transformers_available():
+        return None
+    try:
+        from transformers import pipeline as hf_pipeline
+        return hf_pipeline(
+            "text-classification",
+            model="ProsusAI/finbert",
+            tokenizer="ProsusAI/finbert",
+            top_k=None,
+            device=-1,
+        )
+    except Exception as exc:
+        LOGGER.warning("finbert_features: failed to load ProsusAI/finbert: %s", exc)
+        return None
+
+
+def batch_score_headlines(headlines: list[str]) -> list[dict]:
+    """Score each headline with FinBERT.
+
+    Returns a list of dicts with keys 'positive', 'negative', 'neutral'
+    (probabilities summing to 1.0). Returns fallback zeros if model is
+    unavailable or headline is empty.
+
+    Parameters
+    ----------
+    headlines:
+        List of news headline strings.
+
+    Returns
+    -------
+    list[dict]
+        One dict per headline with keys 'positive', 'negative', 'neutral'.
+    """
+    fallback = {"positive": 0.0, "negative": 0.0, "neutral": 1.0}
+    if not headlines:
+        return []
+
+    pipe = _load_pipeline()
+    if pipe is None:
+        return [dict(fallback) for _ in headlines]
+
+    cleaned = [h.strip()[:512] or "no text" for h in headlines]
+
+    results = []
+    try:
+        raw = pipe(cleaned, batch_size=8, truncation=True)
+        for item in raw:
+            scores = {entry["label"].lower(): entry["score"] for entry in item}
+            results.append({
+                "positive": scores.get("positive", 0.0),
+                "negative": scores.get("negative", 0.0),
+                "neutral": scores.get("neutral", 1.0),
+            })
+    except Exception as exc:
+        LOGGER.warning("finbert_features: inference failed: %s", exc)
+        return [dict(fallback) for _ in headlines]
+
+    return results
+
+
+def aggregate_daily_sentiment(headlines: list[str]) -> float:
+    """Return daily FinBERT sentiment score for a list of headlines.
+
+    Aggregates per-headline scores by averaging
+    (positive_prob - negative_prob) across all headlines.
+
+    Returns a float in [-1, 1]. Returns 0.0 if no headlines.
+    """
+    if not headlines:
+        return 0.0
+
+    scores = batch_score_headlines(headlines)
+    if not scores:
+        return 0.0
+
+    daily = sum(s["positive"] - s["negative"] for s in scores) / len(scores)
+    return max(-1.0, min(1.0, daily))

--- a/fastapi/geo_features.py
+++ b/fastapi/geo_features.py
@@ -1,0 +1,236 @@
+import json
+import logging
+import os
+import threading
+import time
+
+import requests
+
+LOGGER = logging.getLogger("uvicorn.error")
+
+GEO_CACHE_TTL_SECONDS = int(os.getenv("GEO_FEATURES_CACHE_SECONDS", "86400"))
+OPENAI_MIN_INTERVAL_SECONDS = int(os.getenv("OPENAI_MIN_INTERVAL_SECONDS", "60"))
+
+NEWSAPI_ENDPOINT = "https://newsapi.org/v2/everything"
+OPENAI_ENDPOINT = "https://api.openai.com/v1/chat/completions"
+
+ACTOR_ENCODING = {"none": 0, "us": 1, "china": 2, "russia": 3, "other": 4}
+EVENT_TYPE_ENCODING = {
+    "none": 0, "tariff": 1, "sanctions": 2,
+    "conflict": 3, "election": 4, "policy": 5,
+}
+SECTOR_ENCODING = {
+    "none": 0, "energy": 1, "materials": 2, "industrials": 3,
+    "utilities": 4, "healthcare": 5, "financials": 6,
+    "consumer_discretionary": 7, "consumer_staples": 8,
+    "information_technology": 9, "communication_services": 10,
+    "real_estate": 11, "defense": 12, "semiconductors": 13,
+}
+
+ZERO_GEO_FEATURES: dict = {
+    "geo_sentiment_score": 0.0,
+    "geo_event_magnitude": 0.0,
+    "geo_actor_encoded": 0,
+    "geo_event_type_encoded": 0,
+    "geo_affected_sector_encoded": 0,
+    "geo_direction": 0,
+    "gpr_index": 0.0,
+}
+
+GEO_FEATURE_NAMES = list(ZERO_GEO_FEATURES.keys())
+
+_CACHE_LOCK = threading.Lock()
+_CACHE: dict = {
+    "timestamp": 0.0,
+    "date_key": None,
+    "payload": None,
+    "last_openai_attempt": 0.0,
+    "cooldown_until": 0.0,
+}
+
+
+def _clamp(value: float, lo: float, hi: float) -> float:
+    return max(lo, min(hi, value))
+
+
+def _parse_json_blob(text: str) -> dict | None:
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        start = text.find("{")
+        end = text.rfind("}")
+        if start != -1 and end > start:
+            try:
+                return json.loads(text[start : end + 1])
+            except json.JSONDecodeError:
+                pass
+    return None
+
+
+class GeoFeatureExtractor:
+    """Converts geopolitical news headlines into numeric ML features.
+
+    Fetches top-5 headlines via NewsAPI, calls GPT-4o-mini for structured
+    JSON extraction, and caches the result for 24 hours (matching the
+    INSIGHTS_CACHE_TTL_SECONDS pattern in weekly_dashboard.py).
+    """
+
+    def __init__(self) -> None:
+        self._openai_key = os.getenv("OPENAI_API_KEY")
+        self._newsapi_key = os.getenv("NEWSAPI_KEY") or os.getenv("NEWSAPI_API_KEY")
+
+    def get_geo_features(self, ticker: str, date_str: str) -> dict:
+        """Return geo feature dict for (ticker, date_str).
+
+        Features are global-macro (not ticker-specific) so the cache is
+        keyed only by date. ticker is used to refine headline queries.
+        Falls back to ZERO_GEO_FEATURES on any error.
+        """
+        now = time.time()
+        with _CACHE_LOCK:
+            ts = float(_CACHE["timestamp"])
+            key = _CACHE["date_key"]
+            payload = _CACHE["payload"]
+
+        if key == date_str and payload is not None and now - ts < GEO_CACHE_TTL_SECONDS:
+            return dict(payload)
+
+        features = self._extract(ticker, date_str)
+
+        with _CACHE_LOCK:
+            _CACHE["timestamp"] = time.time()
+            _CACHE["date_key"] = date_str
+            _CACHE["payload"] = features
+
+        return dict(features)
+
+    def _extract(self, ticker: str, date_str: str) -> dict:
+        headlines = self._fetch_headlines(ticker, date_str)
+        if not headlines:
+            return dict(ZERO_GEO_FEATURES)
+
+        llm_result = self._call_openai(headlines)
+        if not llm_result:
+            return dict(ZERO_GEO_FEATURES)
+
+        return self._parse_llm_result(llm_result)
+
+    def _fetch_headlines(self, ticker: str, date_str: str) -> list[str]:
+        if not self._newsapi_key:
+            return []
+        query = (
+            "geopolitical OR tariff OR sanctions OR conflict OR election OR policy "
+            "stock market"
+        )
+        try:
+            resp = requests.get(
+                NEWSAPI_ENDPOINT,
+                params={
+                    "q": query,
+                    "from": date_str,
+                    "to": date_str,
+                    "language": "en",
+                    "sortBy": "relevancy",
+                    "pageSize": 5,
+                },
+                headers={"X-Api-Key": self._newsapi_key},
+                timeout=10,
+            )
+            resp.raise_for_status()
+            articles = resp.json().get("articles", [])
+            return [a.get("title", "") for a in articles if a.get("title")]
+        except Exception as exc:
+            LOGGER.warning("geo_features: NewsAPI fetch failed: %s", exc)
+            return []
+
+    def _call_openai(self, headlines: list[str]) -> dict | None:
+        if not self._openai_key:
+            return None
+
+        now = time.time()
+        with _CACHE_LOCK:
+            cooldown = float(_CACHE.get("cooldown_until") or 0.0)
+            last = float(_CACHE.get("last_openai_attempt") or 0.0)
+
+        if now < cooldown or now - last < OPENAI_MIN_INTERVAL_SECONDS:
+            return None
+
+        with _CACHE_LOCK:
+            _CACHE["last_openai_attempt"] = now
+
+        headline_text = "\n".join(f"- {h}" for h in headlines[:5])
+        prompt = (
+            "Analyze these financial news headlines and return a JSON object with:\n"
+            '- actor: one of ["none","us","china","russia","other"]\n'
+            '- event_type: one of ["none","tariff","sanctions","conflict","election","policy"]\n'
+            '- affected_sector: one of ["none","energy","materials","industrials","utilities",'
+            '"healthcare","financials","consumer_discretionary","consumer_staples",'
+            '"information_technology","communication_services","real_estate","defense","semiconductors"]\n'
+            "- direction: -1 (negative), 0 (neutral), or 1 (positive market impact)\n"
+            "- magnitude: float 0.0-1.0 (estimated market impact size)\n"
+            "- sentiment_score: float -1.0-1.0\n\n"
+            f"Headlines:\n{headline_text}\n\nReturn only valid JSON."
+        )
+
+        payload = {
+            "model": os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
+            "temperature": 0.1,
+            "max_tokens": 200,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": (
+                        "You are a financial analyst extracting structured geopolitical "
+                        "features. Return only valid JSON."
+                    ),
+                },
+                {"role": "user", "content": prompt},
+            ],
+        }
+        try:
+            resp = requests.post(
+                OPENAI_ENDPOINT,
+                headers={
+                    "Authorization": f"Bearer {self._openai_key}",
+                    "Content-Type": "application/json",
+                },
+                json=payload,
+                timeout=30,
+            )
+            if resp.status_code == 429:
+                with _CACHE_LOCK:
+                    _CACHE["cooldown_until"] = now + 300
+                return None
+            resp.raise_for_status()
+            content = resp.json()["choices"][0]["message"]["content"]
+            return _parse_json_blob(content)
+        except Exception as exc:
+            LOGGER.warning("geo_features: OpenAI call failed: %s", exc)
+            return None
+
+    def _parse_llm_result(self, result: dict) -> dict:
+        def _safe_float(val, lo: float, hi: float, default: float = 0.0) -> float:
+            try:
+                return _clamp(float(val), lo, hi)
+            except (TypeError, ValueError):
+                return default
+
+        def _safe_int(val, lo: int, hi: int, default: int = 0) -> int:
+            try:
+                return max(lo, min(hi, int(val)))
+            except (TypeError, ValueError):
+                return default
+
+        actor = str(result.get("actor", "none")).lower()
+        event = str(result.get("event_type", "none")).lower()
+        sector = str(result.get("affected_sector", "none")).lower()
+
+        return {
+            "geo_sentiment_score": _safe_float(result.get("sentiment_score"), -1.0, 1.0),
+            "geo_event_magnitude": _safe_float(result.get("magnitude"), 0.0, 1.0),
+            "geo_actor_encoded": ACTOR_ENCODING.get(actor, ACTOR_ENCODING["other"]),
+            "geo_event_type_encoded": EVENT_TYPE_ENCODING.get(event, EVENT_TYPE_ENCODING["none"]),
+            "geo_affected_sector_encoded": SECTOR_ENCODING.get(sector, SECTOR_ENCODING["none"]),
+            "geo_direction": _safe_int(result.get("direction"), -1, 1),
+            "gpr_index": 0.0,
+        }

--- a/fastapi/main.py
+++ b/fastapi/main.py
@@ -42,6 +42,7 @@ from scheduled_updates import get_scheduler_status, set_scheduler_enabled, start
 from weekly_dashboard import build_weekly_alerts, build_weekly_insights, build_weekly_recommendation, build_ticker_signal
 from xg_boost_investor.Features import build_full_features, get_feature_explanations
 from xg_boost_investor.symbol_collector import get_sp500_at_date
+from whatif_router import router as whatif_router
 
 DEFAULT_BOOTSTRAP_START = "2020-01-01"
 
@@ -67,6 +68,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.include_router(whatif_router)
 
 
 @app.on_event("startup")

--- a/fastapi/requirements-test.txt
+++ b/fastapi/requirements-test.txt
@@ -1,0 +1,4 @@
+pytest
+fastapi
+pydantic
+httpx

--- a/fastapi/requirements-test.txt
+++ b/fastapi/requirements-test.txt
@@ -2,3 +2,5 @@ pytest
 fastapi
 pydantic
 httpx
+numpy
+pandas

--- a/fastapi/tests/test_ablation.py
+++ b/fastapi/tests/test_ablation.py
@@ -1,0 +1,69 @@
+"""Tests for the gers module (used by baseline_ablation.py)."""
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent.parent / "eval_scripts"))
+
+import pytest
+
+np = pytest.importorskip("numpy", reason="numpy required for gers tests")
+pd = pytest.importorskip("pandas", reason="pandas required for gers tests")
+
+from gers import compute_gers, identify_shock_days
+
+
+def _make_gpr(values: list[float]) -> pd.Series:
+    idx = pd.date_range("2022-01-01", periods=len(values), freq="D")
+    return pd.Series(values, index=idx, name="gpr_index")
+
+
+def test_compute_gers_no_shocks():
+    gpr = _make_gpr([100.0] * 300)
+    y_true = np.array([0.01] * 50)
+    y_pred = np.array([0.01] * 50)
+    result = compute_gers(y_true, y_pred, gpr)
+    assert np.isnan(result)
+
+
+def test_compute_gers_perfect_on_shock_days():
+    values = [100.0] * 252 + [200.0] * 10 + [100.0] * 38
+    gpr = _make_gpr(values)
+    y_true = np.ones(50)
+    y_pred = np.ones(50) * 0.5
+    result = compute_gers(y_true, y_pred, gpr)
+    assert result == 1.0 or np.isnan(result)
+
+
+def test_compute_gers_wrong_direction_on_shock_days():
+    values = [100.0] * 252 + [300.0, 100.0] * 5 + [100.0] * 38
+    gpr = _make_gpr(values)
+    y_true = np.ones(50)
+    y_pred = np.ones(50) * -0.5
+    result = compute_gers(y_true, y_pred, gpr)
+    if not np.isnan(result):
+        assert result == 0.0
+
+
+def test_compute_gers_length_mismatch_raises():
+    gpr = _make_gpr([100.0] * 300)
+    with pytest.raises(ValueError):
+        compute_gers(np.ones(10), np.ones(20), gpr)
+
+
+def test_identify_shock_days_marks_spike():
+    values = [100.0] * 252 + [500.0] + [100.0] * 50
+    gpr = _make_gpr(values)
+    shocks = identify_shock_days(gpr)
+    assert shocks.any()
+    assert shocks.iloc[252]
+
+
+def test_compute_gers_returns_between_0_and_1():
+    rng = np.random.default_rng(42)
+    values = rng.uniform(50, 200, 300).tolist()
+    gpr = _make_gpr(values)
+    y_true = rng.uniform(-0.05, 0.05, 50)
+    y_pred = rng.uniform(-0.05, 0.05, 50)
+    result = compute_gers(y_true, y_pred, gpr)
+    if not np.isnan(result):
+        assert 0.0 <= result <= 1.0

--- a/fastapi/tests/test_finbert_features.py
+++ b/fastapi/tests/test_finbert_features.py
@@ -1,0 +1,96 @@
+"""Tests for finbert_features.py.
+
+Tests run with transformers mocked - do not require GPU or model download.
+"""
+from unittest.mock import patch
+
+import pytest
+
+
+def _mock_pipe(labels_scores: list[list[tuple[str, float]]]):
+    """Returns a mock pipeline callable matching HuggingFace output format."""
+    def _pipe(texts, **kwargs):
+        out = []
+        for i, _ in enumerate(texts):
+            idx = min(i, len(labels_scores) - 1)
+            out.append([{"label": lbl, "score": sc} for lbl, sc in labels_scores[idx]])
+        return out
+    return _pipe
+
+
+_POSITIVE_OUTPUTS = [
+    [("positive", 0.8), ("negative", 0.1), ("neutral", 0.1)],
+]
+_NEGATIVE_OUTPUTS = [
+    [("positive", 0.1), ("negative", 0.7), ("neutral", 0.2)],
+]
+_NEUTRAL_OUTPUTS = [
+    [("positive", 0.3), ("negative", 0.3), ("neutral", 0.4)],
+]
+
+
+@pytest.fixture
+def mock_positive_pipeline():
+    import finbert_features
+    finbert_features._load_pipeline.cache_clear()
+    pipe = _mock_pipe(_POSITIVE_OUTPUTS * 10)
+    with patch.object(finbert_features, "_load_pipeline", return_value=pipe):
+        yield
+    finbert_features._load_pipeline.cache_clear()
+
+
+@pytest.fixture
+def mock_negative_pipeline():
+    import finbert_features
+    finbert_features._load_pipeline.cache_clear()
+    pipe = _mock_pipe(_NEGATIVE_OUTPUTS * 10)
+    with patch.object(finbert_features, "_load_pipeline", return_value=pipe):
+        yield
+    finbert_features._load_pipeline.cache_clear()
+
+
+def test_batch_score_returns_correct_keys(mock_positive_pipeline):
+    from finbert_features import batch_score_headlines
+    scores = batch_score_headlines(["Fed raises rates"])
+    assert len(scores) == 1
+    assert set(scores[0].keys()) == {"positive", "negative", "neutral"}
+
+
+def test_batch_score_positive_dominates(mock_positive_pipeline):
+    from finbert_features import batch_score_headlines
+    scores = batch_score_headlines(["Stocks rally on earnings beat"])
+    assert scores[0]["positive"] > scores[0]["negative"]
+
+
+def test_aggregate_returns_float_in_range(mock_positive_pipeline):
+    from finbert_features import aggregate_daily_sentiment
+    score = aggregate_daily_sentiment(["headline 1", "headline 2"])
+    assert isinstance(score, float)
+    assert -1.0 <= score <= 1.0
+
+
+def test_aggregate_empty_headlines():
+    from finbert_features import aggregate_daily_sentiment
+    assert aggregate_daily_sentiment([]) == 0.0
+
+
+def test_no_transformers_returns_fallback():
+    import finbert_features
+    finbert_features._load_pipeline.cache_clear()
+    with patch.object(finbert_features, "_load_pipeline", return_value=None):
+        from finbert_features import batch_score_headlines
+        results = batch_score_headlines(["some headline"])
+    assert results[0]["neutral"] == 1.0
+    assert results[0]["positive"] == 0.0
+    finbert_features._load_pipeline.cache_clear()
+
+
+def test_batch_score_empty_input():
+    from finbert_features import batch_score_headlines
+    assert batch_score_headlines([]) == []
+
+
+def test_aggregate_negative_sentiment(mock_negative_pipeline):
+    from finbert_features import aggregate_daily_sentiment
+    score = aggregate_daily_sentiment(["market crash", "stocks tank", "selloff"])
+    assert score < 0

--- a/fastapi/tests/test_whatif_router.py
+++ b/fastapi/tests/test_whatif_router.py
@@ -1,0 +1,85 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.fixture
+def client():
+    with patch("whatif_router._get_baseline_predictions") as mock_baselines, \
+         patch("whatif_router._call_openai_raw") as mock_openai, \
+         patch("whatif_router._extract_scenario_features") as mock_features:
+
+        mock_baselines.return_value = {
+            "SPY": 0.001,
+            "NVDA": 0.003,
+        }
+        mock_openai.return_value = "Scenario summary sentence."
+        mock_features.return_value = {
+            "geo_sentiment_score": -0.5,
+            "geo_event_magnitude": 0.7,
+            "geo_actor_encoded": 1,
+            "geo_event_type_encoded": 1,
+            "geo_affected_sector_encoded": 13,
+            "geo_direction": -1,
+            "gpr_index": 0.0,
+        }
+
+        from fastapi import FastAPI
+        from whatif_router import router
+
+        app = FastAPI()
+        app.include_router(router)
+        yield TestClient(app)
+
+
+def test_whatif_returns_200(client):
+    resp = client.post(
+        "/api/whatif",
+        json={"scenario": "US imposes tariffs on Chinese semiconductors", "tickers": ["SPY", "NVDA"]},
+    )
+    assert resp.status_code == 200
+
+
+def test_whatif_response_schema(client):
+    resp = client.post(
+        "/api/whatif",
+        json={"scenario": "Russia invades Ukraine escalation", "tickers": ["SPY", "NVDA"]},
+    )
+    data = resp.json()
+    assert "scenario_summary" in data
+    assert "predictions" in data
+    assert "disclaimer" in data
+    assert len(data["predictions"]) == 2
+
+
+def test_whatif_predictions_have_delta(client):
+    resp = client.post(
+        "/api/whatif",
+        json={"scenario": "US sanctions on oil exports", "tickers": ["SPY", "NVDA"]},
+    )
+    data = resp.json()
+    for pred in data["predictions"]:
+        assert "ticker" in pred
+        assert "baseline_return" in pred
+        assert "adjusted_return" in pred
+        assert "delta" in pred
+        assert abs(pred["delta"] - (pred["adjusted_return"] - pred["baseline_return"])) < 1e-5
+
+
+def test_whatif_too_many_tickers(client):
+    tickers = [f"TICK{i}" for i in range(11)]
+    resp = client.post(
+        "/api/whatif",
+        json={"scenario": "some event", "tickers": tickers},
+    )
+    assert resp.status_code == 400
+
+
+def test_whatif_disclaimer_present(client):
+    resp = client.post(
+        "/api/whatif",
+        json={"scenario": "nuclear conflict"},
+    )
+    data = resp.json()
+    assert "Not financial advice" in data["disclaimer"]

--- a/fastapi/whatif_router.py
+++ b/fastapi/whatif_router.py
@@ -1,0 +1,222 @@
+import logging
+import os
+import time
+
+import requests
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from geo_features import GeoFeatureExtractor, ZERO_GEO_FEATURES
+
+LOGGER = logging.getLogger("uvicorn.error")
+
+OPENAI_ENDPOINT = "https://api.openai.com/v1/chat/completions"
+WHATIF_DEFAULT_TICKERS = ["SPY", "QQQ", "AAPL", "NVDA", "XOM", "LMT", "TSM"]
+
+_RATE_LOCK = __import__("threading").Lock()
+_LAST_OPENAI_CALL = 0.0
+OPENAI_MIN_INTERVAL_SECONDS = int(os.getenv("OPENAI_MIN_INTERVAL_SECONDS", "60"))
+
+router = APIRouter()
+
+
+class WhatIfRequest(BaseModel):
+    scenario: str = Field(..., description="Free-text hypothetical geopolitical event")
+    tickers: list[str] | None = Field(None, description="Tickers to evaluate; defaults to watchlist")
+    horizon_days: int = Field(5, ge=1, le=30)
+
+
+class TickerPrediction(BaseModel):
+    ticker: str
+    baseline_return: float
+    adjusted_return: float
+    delta: float
+    confidence: float
+    narrative: str
+
+
+class WhatIfResponse(BaseModel):
+    scenario_summary: str
+    extracted_features: dict
+    predictions: list[TickerPrediction]
+    disclaimer: str
+
+
+def _call_openai_raw(prompt: str, max_tokens: int = 300) -> str | None:
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        return None
+
+    global _LAST_OPENAI_CALL
+    now = time.time()
+    with _RATE_LOCK:
+        wait = OPENAI_MIN_INTERVAL_SECONDS - (now - _LAST_OPENAI_CALL)
+        if wait > 0:
+            time.sleep(wait)
+        _LAST_OPENAI_CALL = time.time()
+
+    payload = {
+        "model": os.getenv("OPENAI_MODEL", "gpt-4o-mini"),
+        "temperature": 0.3,
+        "max_tokens": max_tokens,
+        "messages": [
+            {
+                "role": "system",
+                "content": "You are a concise financial market analyst. Provide informational analysis only, no investment advice.",
+            },
+            {"role": "user", "content": prompt},
+        ],
+    }
+    try:
+        resp = requests.post(
+            OPENAI_ENDPOINT,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json=payload,
+            timeout=30,
+        )
+        resp.raise_for_status()
+        return resp.json()["choices"][0]["message"]["content"].strip()
+    except Exception as exc:
+        LOGGER.warning("whatif: OpenAI call failed: %s", exc)
+        return None
+
+
+def _extract_scenario_features(scenario: str) -> dict:
+    """Use GeoFeatureExtractor to parse scenario into numeric features."""
+    extractor = GeoFeatureExtractor()
+    if not extractor._openai_key:
+        return dict(ZERO_GEO_FEATURES)
+
+    prompt = (
+        f'Scenario: "{scenario}"\n\n'
+        "Extract structured features and return JSON with:\n"
+        '- actor: ["none","us","china","russia","other"]\n'
+        '- event_type: ["none","tariff","sanctions","conflict","election","policy"]\n'
+        '- affected_sector: ["none","energy","materials","industrials","utilities","healthcare",'
+        '"financials","consumer_discretionary","consumer_staples","information_technology",'
+        '"communication_services","real_estate","defense","semiconductors"]\n'
+        "- direction: -1, 0, or 1 (market impact)\n"
+        "- magnitude: 0.0-1.0 (impact size)\n"
+        "- sentiment_score: -1.0-1.0\n"
+        "Return only valid JSON."
+    )
+    raw = extractor._call_openai([scenario])
+    if raw:
+        return extractor._parse_llm_result(raw)
+    return dict(ZERO_GEO_FEATURES)
+
+
+def _compute_adjusted_return(baseline: float, geo_features: dict) -> tuple[float, float]:
+    """Apply geo feature adjustment to baseline prediction.
+
+    Uses a linear heuristic: direction * magnitude scales the baseline.
+    Confidence reflects the LLM's certainty (magnitude proxy).
+    Returns (adjusted_return, confidence).
+    """
+    direction = geo_features.get("geo_direction", 0)
+    magnitude = geo_features.get("geo_event_magnitude", 0.0)
+    sensitivity = 0.015
+
+    adjustment = direction * magnitude * sensitivity
+    adjusted = baseline + adjustment
+    confidence = max(0.3, min(0.9, 0.5 + magnitude * 0.4))
+    return adjusted, confidence
+
+
+def _get_baseline_predictions(tickers: list[str]) -> dict[str, float]:
+    """Call XGBoostInvestor to get baseline predictions for each ticker."""
+    try:
+        import pandas as pd
+        from xg_boost_investor import XGBoostInvestor
+        from xg_boost_investor.Features import build_full_features
+
+        results: dict[str, float] = {}
+        for ticker in tickers:
+            try:
+                market_conditions, _ = build_full_features([ticker], today=True)
+                xgb = XGBoostInvestor.XGBoostInvestor()
+                xgb.load("xg_boost_investor/model_save/model/xgboost_investor")
+                df = pd.DataFrame(market_conditions).reset_index(drop=True)
+                X, _, _, _ = xgb.prepare_predictions(df, pd.DataFrame({"ret_1d": [0]}))
+                pred = xgb.predict(X)
+                results[ticker] = float(pred[-1]) if len(pred) > 0 else 0.0
+            except Exception as exc:
+                LOGGER.warning("whatif: baseline prediction failed for %s: %s", ticker, exc)
+                results[ticker] = 0.0
+        return results
+    except ImportError as exc:
+        LOGGER.warning("whatif: XGBoostInvestor not available: %s", exc)
+        return {t: 0.0 for t in tickers}
+
+
+def _generate_narrative(ticker: str, scenario: str, features: dict, delta: float) -> str:
+    direction_word = "positive" if delta > 0 else ("negative" if delta < 0 else "neutral")
+    prompt = (
+        f'Given this hypothetical scenario: "{scenario}"\n'
+        f"Extracted event type: {features.get('geo_event_type_encoded')}, "
+        f"actor: {features.get('geo_actor_encoded')}, "
+        f"sector impact: {features.get('geo_affected_sector_encoded')}\n"
+        f"Expected {direction_word} market impact for {ticker}.\n\n"
+        f"In 1-2 sentences, explain why {ticker} would be affected. "
+        "Focus on supply chain, sector exposure, or macro sensitivity. No investment advice."
+    )
+    narrative = _call_openai_raw(prompt, max_tokens=80)
+    if not narrative:
+        return f"Scenario may have a {direction_word} effect on {ticker} based on sector and geopolitical exposure."
+    return narrative
+
+
+@router.post("/api/whatif", response_model=WhatIfResponse)
+def what_if(request: WhatIfRequest) -> WhatIfResponse:
+    tickers = [t.upper() for t in (request.tickers or WHATIF_DEFAULT_TICKERS)]
+    if len(tickers) > 10:
+        raise HTTPException(status_code=400, detail="Maximum 10 tickers per request")
+
+    geo_features = _extract_scenario_features(request.scenario)
+
+    scenario_summary_raw = _call_openai_raw(
+        f'Summarize this scenario in one sentence: "{request.scenario}"',
+        max_tokens=60,
+    )
+    scenario_summary = scenario_summary_raw or request.scenario
+
+    extracted = {
+        "actor": geo_features.get("geo_actor_encoded"),
+        "event_type": geo_features.get("geo_event_type_encoded"),
+        "affected_sector": geo_features.get("geo_affected_sector_encoded"),
+        "direction": geo_features.get("geo_direction"),
+        "magnitude": geo_features.get("geo_event_magnitude"),
+    }
+
+    baselines = _get_baseline_predictions(tickers)
+
+    predictions: list[TickerPrediction] = []
+    for ticker in tickers:
+        baseline = baselines.get(ticker, 0.0)
+        adjusted, confidence = _compute_adjusted_return(baseline, geo_features)
+        delta = adjusted - baseline
+
+        narrative = _generate_narrative(ticker, request.scenario, geo_features, delta)
+
+        predictions.append(
+            TickerPrediction(
+                ticker=ticker,
+                baseline_return=round(baseline, 6),
+                adjusted_return=round(adjusted, 6),
+                delta=round(delta, 6),
+                confidence=round(confidence, 4),
+                narrative=narrative,
+            )
+        )
+
+    predictions.sort(key=lambda p: p.delta)
+
+    return WhatIfResponse(
+        scenario_summary=scenario_summary,
+        extracted_features=extracted,
+        predictions=predictions,
+        disclaimer="Hypothetical scenario. Not financial advice.",
+    )

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+pythonpath = fastapi

--- a/stockai-web/src/components/WhatIfCard.tsx
+++ b/stockai-web/src/components/WhatIfCard.tsx
@@ -1,0 +1,122 @@
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Stack,
+  TextField,
+  Tooltip,
+  Typography,
+} from '@mui/material'
+import { useState } from 'react'
+import { postWhatIf, type WhatIfResponse } from '../services/api'
+
+function DeltaChip({ delta }: { delta: number }) {
+  const pct = (delta * 100).toFixed(2)
+  const color = delta > 0 ? 'success' : delta < 0 ? 'error' : 'default'
+  const label = delta >= 0 ? `+${pct}%` : `${pct}%`
+  return <Chip label={label} color={color} size="small" />
+}
+
+function ResultTable({ response }: { response: WhatIfResponse }) {
+  return (
+    <Stack spacing={1.5} mt={1}>
+      <Typography variant="subtitle2" color="text.secondary">
+        {response.scenario_summary}
+      </Typography>
+      {response.predictions.map((p) => (
+        <Box
+          key={p.ticker}
+          sx={{
+            p: 1.5,
+            borderRadius: 1,
+            border: '1px solid',
+            borderColor: 'divider',
+          }}
+        >
+          <Stack direction="row" alignItems="center" spacing={1} mb={0.5}>
+            <Typography variant="body2" fontWeight={600}>
+              {p.ticker}
+            </Typography>
+            <DeltaChip delta={p.delta} />
+            <Tooltip title={`Confidence: ${(p.confidence * 100).toFixed(0)}%`}>
+              <Typography variant="caption" color="text.disabled">
+                {(p.confidence * 100).toFixed(0)}% conf.
+              </Typography>
+            </Tooltip>
+          </Stack>
+          <Typography variant="caption" color="text.secondary">
+            {p.narrative}
+          </Typography>
+        </Box>
+      ))}
+      <Typography variant="caption" color="text.disabled" mt={1}>
+        {response.disclaimer}
+      </Typography>
+    </Stack>
+  )
+}
+
+export default function WhatIfCard() {
+  const [scenario, setScenario] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [result, setResult] = useState<WhatIfResponse | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  async function handleSubmit() {
+    if (!scenario.trim()) return
+    setLoading(true)
+    setError(null)
+    setResult(null)
+    try {
+      const response = await postWhatIf({ scenario: scenario.trim() })
+      setResult(response)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Request failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <Card variant="outlined">
+      <CardContent>
+        <Typography variant="h6" gutterBottom>
+          What If? Scenario Explorer
+        </Typography>
+        <Typography variant="body2" color="text.secondary" mb={2}>
+          Describe a hypothetical geopolitical event and see its predicted impact on key stocks.
+        </Typography>
+        <Stack direction="row" spacing={1} alignItems="flex-start">
+          <TextField
+            fullWidth
+            size="small"
+            placeholder='e.g. "US imposes 25% tariffs on Chinese semiconductors"'
+            value={scenario}
+            onChange={(e) => setScenario(e.target.value)}
+            onKeyDown={(e) => e.key === 'Enter' && !e.shiftKey && handleSubmit()}
+            disabled={loading}
+          />
+          <Button
+            variant="contained"
+            size="small"
+            onClick={handleSubmit}
+            disabled={loading || !scenario.trim()}
+            sx={{ whiteSpace: 'nowrap', minWidth: 80 }}
+          >
+            {loading ? <CircularProgress size={16} color="inherit" /> : 'Analyze'}
+          </Button>
+        </Stack>
+        {error && (
+          <Alert severity="error" sx={{ mt: 2 }}>
+            {error}
+          </Alert>
+        )}
+        {result && <ResultTable response={result} />}
+      </CardContent>
+    </Card>
+  )
+}

--- a/stockai-web/src/pages/Dashboard.tsx
+++ b/stockai-web/src/pages/Dashboard.tsx
@@ -4,6 +4,7 @@ import Footer from "../components/Footer";
 import WeeklyInsightsSection from "../components/WeeklyInsightsSection";
 import WeeklyPriceAlertsCard from "../components/WeeklyPriceAlertsCard";
 import WeeklyRecommendationCard from "../components/WeeklyRecommendationCard";
+import WhatIfCard from "../components/WhatIfCard";
 import PageHeader from "../components/PageHeader";
 import { GradientText } from "../themes/styles";
 import {DailyTabularInsightsSection} from "../components/DailyTabularInsightsSection.tsx";
@@ -20,6 +21,9 @@ export default function Dashboard() {
       <WeeklyPriceAlertsCard />
       <Container maxWidth="lg" sx={{ py: { xs: 2, md: 3 } }}>
         <WeeklyRecommendationCard />
+      </Container>
+      <Container maxWidth="lg" sx={{ py: { xs: 2, md: 3 } }}>
+        <WhatIfCard />
       </Container>
       <WeeklyInsightsSection />
         <DailyTabularInsightsSection />

--- a/stockai-web/src/services/api.ts
+++ b/stockai-web/src/services/api.ts
@@ -257,3 +257,32 @@ export type TickerSignalResponse = {
   model: string | null
   note: string | null
 }
+
+export type WhatIfRequest = {
+  scenario: string
+  tickers?: string[]
+  horizon_days?: number
+}
+
+export type TickerWhatIfPrediction = {
+  ticker: string
+  baseline_return: number
+  adjusted_return: number
+  delta: number
+  confidence: number
+  narrative: string
+}
+
+export type WhatIfResponse = {
+  scenario_summary: string
+  extracted_features: Record<string, number | null>
+  predictions: TickerWhatIfPrediction[]
+  disclaimer: string
+}
+
+export function postWhatIf(payload: WhatIfRequest) {
+  return requestJson<WhatIfResponse>('/api/whatif', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
+}


### PR DESCRIPTION
## Summary

Closes #22. **Depends on #21** (ablation study infrastructure).

- Adds `fastapi/finbert_features.py`:
  - `batch_score_headlines(headlines)` - returns per-headline `{positive, negative, neutral}` probability dicts using `ProsusAI/finbert`
  - `aggregate_daily_sentiment(headlines)` - aggregates to a daily `finbert_sentiment` float in [-1, 1]
  - Lazy import: `transformers` is only imported inside `_load_pipeline()` - no crash if not installed
  - Falls back to `{neutral: 1.0}` if transformers unavailable or model fails to load
- Updates `eval_scripts/baseline_ablation.py` to support `--baselines B2b`:
  - Fetches NewsAPI headlines per day, scores with FinBERT, injects `finbert_sentiment` column into XGBoost features
  - Results added to `results/ablation_results.csv` alongside B0-B3

## Installation

```bash
pip install transformers torch  # for actual FinBERT scoring
# or: pip install transformers[cpu] for CPU-only
```

## Usage

```bash
python eval_scripts/baseline_ablation.py --baselines B0 B2b --skip-llm
```

## Acceptance Criteria

- [x] `finbert_features.py` produces a daily sentiment score from a list of headlines
- [x] B2b results can be added to `results/ablation_results.csv` (via updated ablation script)
- [ ] Head-to-head table: FinBERT vs GPT structured features (requires running full ablation)

## Test plan

- [x] `pytest fastapi/tests/test_finbert_features.py` - 7 tests pass (no model download)
- [ ] Integration: install transformers, confirm `batch_score_headlines(["Fed raises rates"])` returns meaningful scores