### PR TITLE
feat(#24): geo-grounding metric for LLM evaluation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,41 @@
+## Workflow Orchestration
+### 1. Plan mode default
+- Enter plan for for ANY non-trivial tasks (3+ steps or architectural decisions)
+- If something goes sideways, STOP and re-plan immediately
+- Use plan mode for verification steps, not just building
+- Write detailed specs upfront to reduce ambiguitiy
+### 2. Subagent Strategy
+- Use subagents liberally to keep main context window clean
+- Offload research, exploration, and parallel analyis to subagents
+- For complex problems that need a lot of compute, do NOT throw more compute at it. Write a script for the user to run locally.
+- One task per subagent for focused execution
+### 3. Self-Improvement
+- After ANY correction from the user: update tasks/lessons.md with the pattern
+- Write rules for yourself that prevent the same mistake
+- Ruthelessly iterate on these lessons until mistake rate drops
+- Review lessons at session start for relevent project
+- If you write code that can be written with less code. Rewrite it.
+### 4. Verification Before Done
+- Never mark a task complete without proving it works
+- Diff behavior between main and your changes when relevant
+- Ask yourself: "would a staff engineer approve this?"
+- Run tests, check logs, demonstrate correctness
+### 5. Demand Elegance
+- For non-trivial changes: pause and ask "is there a more elegant way?"
+- If a fix feels hacky: "knowing everything I know now, implement the elegant solution"
+- skip this for simple obvious fixes. Do NOT over-engineer.
+- Challenge your own work before presenting it
+## Task Management
+1. Plan first: write plan to tasks/todo.md with checkable items
+2. Verify plan: Check in before starting implementation
+3. Track Progress: mark items complete as you go
+4. Explain changes: high-level summary at each step
+5. Document results: Add Review section tacks/todo.md
+6. Capture lessons: updatetasks/lessons.md after corrections
+
+## Core Principles
+- Simplicity First: Make every change as simple as possible. Impact minimal code, with minimal code.
+- No Laziness: Find root causes. No temporary fixes. Senior Developer standards.
+- Minimal impact: Only touch what's necessary. No side effects with new bugs.
+- Do NOT use non-ascii characters like the em dash. Do Not use ANY unicode in code, comments, or writing.
+- You always do PHD level work.

--- a/docs/diagrams/data-flow.md
+++ b/docs/diagrams/data-flow.md
@@ -1,0 +1,102 @@
+# Data Flow
+
+Overview of how data flows through the AI Stock Trading Platform, covering user-initiated requests (React -> Nginx -> FastAPI -> SQLite/External APIs) and the background scheduled refresh pipeline.
+
+```mermaid
+sequenceDiagram
+    participant React as React Frontend
+    participant Nginx as Nginx (:8080)
+    participant API as FastAPI (:5000)
+    participant Cache as In-Memory Cache
+    participant DB as SQLite (stocks.db)
+    participant YF as Yahoo Finance
+    participant News as NewsAPI
+    participant OpenAI as OpenAI API
+    participant XGB as XGBoost Model
+    participant Sched as APScheduler
+
+    Note over React,OpenAI: === Price Data & Bars Retrieval ===
+    React->>Nginx: GET /api/bars?symbol=AAPL
+    Nginx->>API: proxy /api/*
+    API->>Cache: check BARS_CACHE (24h TTL)
+    alt cache miss
+        API->>DB: SELECT FROM bars WHERE symbol, timeframe, date range
+        DB-->>API: OHLCV rows
+        API->>Cache: store result
+    end
+    API-->>React: {results: Bar[]}
+
+    Note over React,OpenAI: === Weekly Insights (NewsAPI + OpenAI) ===
+    React->>Nginx: GET /api/weekly-insights
+    Nginx->>API: proxy
+    API->>Cache: check INSIGHTS_CACHE (24h TTL)
+    alt cache miss
+        API->>DB: weekly range + core/benchmark symbol changes + top/bottom movers
+        API->>News: GET /v2/everything (market news, last 7 days)
+        News-->>API: articles[]
+        API->>OpenAI: POST /v1/chat/completions (market data + news prompt)
+        OpenAI-->>API: {market_insights[], event_impacts[]}
+        API->>Cache: store payload
+    end
+    API-->>React: insights, events, event_impacts
+
+    Note over React,OpenAI: === Weekly Recommendation (LLM Pick) ===
+    React->>Nginx: GET /api/weekly-recommendation?risk=mid
+    Nginx->>API: proxy
+    API->>DB: movers + core changes + benchmarks
+    API->>XGB: build_full_features() for candidates
+    API->>News: fetch market events
+    API->>OpenAI: prompt with features + risk preference
+    OpenAI-->>API: {symbol, action, reasoning, confidence}
+    API-->>React: recommendation payload
+
+    Note over React,OpenAI: === Ticker Signal (BUY/SELL) ===
+    React->>Nginx: GET /api/ticker-signal?symbol=NVDA
+    Nginx->>API: proxy
+    API->>XGB: build_full_features() + predict()
+    API->>DB: get_forecast() via Darts time-series
+    API->>DB: get_dtw_patterns() pattern recognition
+    API->>News: symbol-specific + market news
+    API->>OpenAI: prompt with features, forecast, patterns, news
+    OpenAI-->>API: {signal: BUY/SELL, reasoning, key_factors}
+    API-->>React: ticker signal response
+
+    Note over React,OpenAI: === Forecasts & Patterns ===
+    React->>Nginx: GET /api/getForecasts?symbol=AAPL
+    Nginx->>API: proxy
+    API->>DB: historical bars for Darts forecasting
+    API-->>React: {results: forecast series[]}
+
+    React->>Nginx: GET /api/getPatterns?symbol=AAPL
+    Nginx->>API: proxy
+    API->>DB: historical bars for DTW pattern matching
+    API-->>React: {results: similar patterns[]}
+
+    Note over Sched,DB: === Background Scheduled Refresh (Sundays 03:00) ===
+    Sched->>API: run_scheduled_update() via CronTrigger
+    API->>DB: load all symbols from symbols table
+    API->>YF: yf.download() in chunks of 50
+    YF-->>API: OHLCV DataFrame (last 7 days)
+    API->>DB: INSERT INTO bars (deduplicated upsert)
+```
+
+## Key Flows
+
+- **Price Data (Bars)**: Frontend calls `/api/bars`, FastAPI checks a 24-hour in-memory cache keyed by `symbol:timeframe:start:end:order:limit`, then queries the `bars` table in SQLite on cache miss. Used by `StockHistoryService` and `fetchBars()`.
+
+- **Weekly Insights**: `/api/weekly-insights` gathers core symbol changes (NVDA, AAPL, MSFT, etc.), benchmark changes (SPY, QQQ, DIA, IWM), top/bottom weekly movers from SQLite, fetches news articles from NewsAPI `/v2/everything`, then sends all data as a structured JSON prompt to OpenAI `gpt-4o-mini` for market insight bullets and event impact analysis. Results are cached for 24 hours with rate-limit cooldown logic.
+
+- **Weekly Recommendation**: `/api/weekly-recommendation` extends the insights pipeline by also calling `build_full_features()` from the XGBoost module to gather quantitative feature snapshots (momentum, volatility, beta, alpha) for candidate stocks, then asks OpenAI to pick ONE stock given a risk preference (low/mid/high).
+
+- **Ticker Signal (BUY/SELL)**: `/api/ticker-signal` is the most data-intensive endpoint -- it aggregates XGBoost features + predictions, Darts time-series forecasts, DTW pattern matches, market news, and symbol-specific news from NewsAPI, then sends everything to OpenAI for a BUY/SELL decision with reasoning and key factors.
+
+- **Forecasts**: `/api/getForecasts` calls `forecasting.get_forecast()` which uses the Darts library to produce time-series forecasts from historical bar data in SQLite.
+
+- **Pattern Matching**: `/api/getPatterns` calls `pattern_recognition.get_dtw_patterns()` which uses Dynamic Time Warping on historical bars to find similar price patterns.
+
+- **Ticker Conditions**: `/api/getCurrentTickerConditions` builds full XGBoost features for a symbol and runs the trained model to produce a prediction, cached for 24 hours.
+
+- **Background Refresh**: APScheduler runs `run_scheduled_update()` every Sunday at 03:00 (configurable timezone). It loads all symbols from the `symbols` table, downloads the last 7 days of data from Yahoo Finance via `yf.download()` in chunks of 50 tickers, and inserts new rows into `bars` with deduplication. Scheduler state is persisted in the `app_settings` table.
+
+---
+*Generated on 2026-03-26*

--- a/docs/diagrams/system-architecture.md
+++ b/docs/diagrams/system-architecture.md
@@ -1,0 +1,88 @@
+# System Architecture
+
+Overview of the AI Stock Trading Platform showing how the frontend, backend, database, and external services connect.
+
+```mermaid
+flowchart TD
+    subgraph Client["Browser (Port 8080)"]
+        HOME["Home Page"]
+        DATA["Data Search"]
+        DASH["Dashboard"]
+        ADMIN["Admin Panel"]
+    end
+
+    subgraph Web["Web Container — Nginx"]
+        NGINX["Nginx Reverse Proxy\n:8080"]
+    end
+
+    subgraph API["FastAPI Container — Uvicorn :5000"]
+        MAIN["FastAPI App"]
+        WEEKLY["Weekly Dashboard\nInsights, Alerts, Recommendations"]
+        FORECAST["Forecasting Engine\nDarts Time Series"]
+        PATTERN["Pattern Recognition\nDTW Matching"]
+        XGBOOST["XGBoost Investor\nML Signals & Features"]
+        FETCH["Price Fetcher"]
+        MOVERS["Weekly Movers"]
+        SCHEDULER["APScheduler\nBackground Jobs"]
+    end
+
+    subgraph DB["Storage"]
+        SQLITE[("SQLite WAL\nstocks.db ~17GB")]
+    end
+
+    subgraph External["External Services"]
+        OPENAI["OpenAI API\nChat Completions"]
+        NEWSAPI["NewsAPI\nMarket News"]
+        YAHOO["Yahoo Finance\nPrice Data"]
+        FRED["FRED API\nEconomic Indicators"]
+    end
+
+    HOME & DATA & DASH & ADMIN -->|HTTP| NGINX
+    NGINX -->|"/api/*"| MAIN
+    NGINX -->|"Static assets"| NGINX
+
+    MAIN --> WEEKLY
+    MAIN --> FORECAST
+    MAIN --> PATTERN
+    MAIN --> XGBOOST
+    MAIN --> FETCH
+    MAIN --> MOVERS
+
+    SCHEDULER -->|"Scheduled refresh"| FETCH
+
+    WEEKLY -->|"Generate insights"| OPENAI
+    WEEKLY -->|"Fetch headlines"| NEWSAPI
+    FETCH -->|"Download OHLCV"| YAHOO
+    XGBOOST -->|"Economic data"| FRED
+
+    MAIN -->|"Read/Write"| SQLITE
+    WEEKLY -->|"Read movers"| SQLITE
+    FETCH -->|"Write bars"| SQLITE
+    XGBOOST -->|"Read features"| SQLITE
+
+    classDef frontend fill:#4285F4,stroke:#333,color:#fff
+    classDef backend fill:#34A853,stroke:#333,color:#fff
+    classDef database fill:#FA7B17,stroke:#333,color:#fff
+    classDef external fill:#EA4335,stroke:#333,color:#fff
+    classDef proxy fill:#9C27B0,stroke:#333,color:#fff
+
+    class HOME,DATA,DASH,ADMIN frontend
+    class MAIN,WEEKLY,FORECAST,PATTERN,XGBOOST,FETCH,MOVERS,SCHEDULER backend
+    class SQLITE database
+    class OPENAI,NEWSAPI,YAHOO,FRED external
+    class NGINX proxy
+```
+
+## Key Components
+
+- **Nginx Reverse Proxy**: Serves the React SPA and forwards `/api/*` requests to FastAPI
+- **FastAPI App**: Central API layer with 20+ endpoints for price data, forecasts, patterns, and insights
+- **Weekly Dashboard**: Generates LLM-powered market summaries, alerts, and purchase recommendations via OpenAI
+- **Forecasting Engine**: Darts-based time series forecasting for stock price prediction
+- **Pattern Recognition**: Dynamic Time Warping (DTW) to find similar historical chart patterns
+- **XGBoost Investor**: ML model using technical indicators + FRED economic data for trade signals
+- **APScheduler**: Runs background jobs (weekly Yahoo Finance refresh)
+- **SQLite**: Single WAL-mode database (~17GB) storing all OHLCV price data
+
+---
+*Generated on 2026-03-26*

--- a/docs/diagrams/weekly-insights-pipeline.md
+++ b/docs/diagrams/weekly-insights-pipeline.md
@@ -1,0 +1,68 @@
+# Weekly Insights Pipeline
+
+End-to-end flow for generating weekly market insights, alerts, and purchase recommendations. The pipeline gathers movers data from SQLite, fetches news headlines from NewsAPI, builds structured prompts, calls OpenAI with retry/rate-limit logic, and caches results behind thread locks with a 24-hour TTL.
+
+```mermaid
+flowchart TD
+    A["/api/weekly-insights\n/api/weekly-alerts\n/api/weekly-recommendation"] --> B{Cache Hit?\nTTL 86400s}
+    B -->|Yes| C[Return Cached Payload]
+    B -->|No| D{Cooldown Active?\nMin 60s between calls}
+    D -->|Yes| E[Return Stale Cache\n+ Cooldown Note]
+    D -->|No| F[Get Weekly Date Range\nMAX date from bars table]
+
+    F --> G[Fetch Core Symbol Changes\nNVDA, AAPL, MSFT, AMZN,\nGOOGL, META, TSLA, etc.]
+    F --> H[Fetch Benchmark Changes\nSPY, QQQ, DIA, IWM]
+    F --> I[Fetch Top/Bottom Movers\nSQL pct_change with\nvolume filter]
+    F --> J[Load Events\nNewsAPI / ENV / URL]
+
+    G --> K[Build JSON Prompt]
+    H --> K
+    I --> K
+    J --> K
+
+    I --> L[Build Alerts\nCore + Top + Bottom\nDeduplicated, max 20]
+    L --> M[Fetch Featured Series\nSpark-line data for top 9]
+    M --> N[Cache Alerts Payload\nALERTS_CACHE_LOCK]
+
+    K --> O[Record last_openai_attempt\nINSIGHTS_CACHE_LOCK]
+    O --> P[Call OpenAI API\ngpt-4o-mini, temp 0.4]
+    P --> Q{Rate Limited?\nHTTP 429}
+    Q -->|Yes| R[Exponential Backoff\nRetry up to 2x]
+    R --> P
+    Q -->|No| S[Parse JSON Response\nmarket_insights + event_impacts]
+
+    S --> T{Recommendation\nEndpoint?}
+    T -->|Yes| U[Parse Single Stock Pick\nsymbol, action, reasoning,\nconfidence, predicted_move]
+    T -->|No| V[Split Markdown Sections\nMarket vs Event bullets]
+
+    U --> W[Cache Result\nRECOMMENDATION_CACHE_LOCK\nKeyed by end_int:risk]
+    V --> X[Cache Result\nINSIGHTS_CACHE_LOCK\nKeyed by end_int + events_sig]
+
+    W --> Y[Return JSON Payload]
+    X --> Y
+
+    classDef frontend fill:#4285F4,stroke:#333,color:#fff
+    classDef backend fill:#34A853,stroke:#333,color:#fff
+    classDef database fill:#FA7B17,stroke:#333,color:#fff
+    classDef external fill:#EA4335,stroke:#333,color:#fff
+
+    class A frontend
+    class B,D,T backend
+    class C,E,N,W,X,Y backend
+    class F,G,H,I,L,M database
+    class J,P,Q,R external
+    class K,O,S,U,V backend
+```
+
+## Key Components
+
+- **Three Endpoints**: `/api/weekly-insights` (market bullets), `/api/weekly-alerts` (price alerts with spark-lines), `/api/weekly-recommendation` (single stock pick with risk preference: low/mid/high)
+- **Movers Calculation** (`WeeklyMovers.py`): SQL query computes `pct_change` between start/end trading day close prices, with optional average volume filter (`DEFAULT_MIN_VOLUME = 2,000,000`), cached per `(direction, min_volume)` key
+- **Events Loading** (`_load_events`): Tries three sources in order: `MARKET_EVENTS_JSON` env var, NewsAPI (`/v2/everything` with market query, up to 12 articles), or `MARKET_EVENTS_URL` fallback
+- **OpenAI Call** (`_call_openai`): Uses `gpt-4o-mini` by default, temperature 0.4, max 500 tokens, system prompt as "concise market analyst", retries up to 2x with exponential backoff (1-8s), handles 429 with Retry-After header
+- **Caching/Locking**: Three independent caches with `threading.Lock` -- `INSIGHTS_CACHE` (single dict, keyed by `end_int` + events signature), `ALERTS_CACHE` (keyed by `end_int:min_volume`), `RECOMMENDATION_CACHE` (keyed by `end_int:risk_strategy`), all with 24-hour TTL
+- **Cooldown Mechanism**: 60s minimum between OpenAI calls (`OPENAI_MIN_INTERVAL_SECONDS`), 300s cooldown after rate-limit, 60s cooldown after other errors
+- **Recommendation Extras**: Gathers XGBoost feature snapshots (`_get_feature_summaries`) for candidate stocks, includes risk preference description in prompt, returns structured JSON with symbol/action/reasoning/confidence
+
+---
+*Generated on 2026-03-26*

--- a/docs/diagrams/xgboost-investor-pipeline.md
+++ b/docs/diagrams/xgboost-investor-pipeline.md
@@ -1,0 +1,66 @@
+# XGBoost Investor Pipeline
+
+End-to-end pipeline for the XGBoost-based stock return prediction system. Covers feature engineering from Yahoo Finance, FRED, and VIX data, model training with BaggingRegressor + XGBRegressor, isotonic calibration, and integration with the FastAPI endpoints for real-time ticker signals and conditions.
+
+```mermaid
+flowchart TD
+    A[S&P 500 Membership\nsymbol_collector.py\nWikipedia scrape + change log] --> B[Download Price Data\nyfinance: tickers, SPY, VIX, RSP]
+
+    B --> C[Technical Features\nret 1/5/10/20/60/120/252d\nmomentum_12_1\nMA distance 20/60/200d]
+    B --> D[Volatility Features\nrealized_vol 20/60/120d\ndownside_vol_60d\nATR 14d, HL range 10d]
+    B --> E[Volume Features\nvolume_zscore_20d\nvolume_trend_slope_60d\ndollar_vol, spike_ratio]
+    B --> F[Relative Strength\nbeta_spy_60d\nput_call_ratio proxy]
+
+    C --> G[Merge All Features\nper-ticker DataFrame]
+    D --> G
+    E --> G
+    F --> G
+
+    G --> H[Market Breadth\npct_above 50/200d MA\nadv/decline ratio\n52w high/low, RSP vs SPY]
+    G --> I[VIX Indicators\nVIX_5d/20d change\nterm structure\nVIX/realized vol ratio]
+    G --> J[FRED Macro Data\n10Y/2Y yields, CPI\nUnemployment, FedFunds\nIndustrial Prod, Money Mkt]
+    G --> K[Time Embeddings\nsin/cos weekday\nsin/cos month\nsin/cos year]
+
+    H --> L[Full Feature Matrix\n~45 features per ticker-day]
+    I --> L
+    J --> L
+    K --> L
+
+    L --> M[Quarterly Data Chunks\n8 quarters look-back\nretrain_model]
+    M --> N[prepare_training\nRobustScaler fit_transform\nDrop constant cols + NaN rows]
+    N --> O[BaggingRegressor\n100 estimators, 80% samples\nXGBRegressor base\nlr=0.05, depth=6]
+    O --> P[Isotonic Calibration\nLast 20% of training data]
+    P --> Q[Save Model\n5 pickle files:\nmodel, x_scaler, y_scaler\nconstant_cols, calibrator]
+
+    L --> R[prepare_predictions\nRobustScaler transform\nTarget: next-day return]
+    Q --> R
+    R --> S[Predict\nBagging predict\nIsotonic calibrate\nInverse scale]
+
+    S --> T["/api/getCurrentTickerConditions"\nFeatures + prediction\nfor single ticker]
+    S --> U["/api/ticker-signal"\nXGBoost pred + forecasts\n+ patterns + news\nto OpenAI for BUY/SELL]
+    S --> V[Simulator.py\nBacktest yearly\nTop-20 daily picks\nPortfolio tracking]
+    V --> W[Metrics.py\nSharpe, Sortino, Calmar\nDrawdown, Win Rate\nVisualizations + Excel]
+
+    classDef frontend fill:#4285F4,stroke:#333,color:#fff
+    classDef backend fill:#34A853,stroke:#333,color:#fff
+    classDef database fill:#FA7B17,stroke:#333,color:#fff
+    classDef external fill:#EA4335,stroke:#333,color:#fff
+
+    class T,U frontend
+    class C,D,E,F,G,H,I,K,L,M,N,O,P,Q,R,S,V,W backend
+    class A,B,J external
+```
+
+## Key Components
+
+- **Symbol Collection** (`symbol_collector.py`): Reconstructs historical S&P 500 membership at any date by scraping Wikipedia's current list and unwinding the change log backward
+- **Feature Engineering** (`Features.py`): Builds ~45 features per ticker-day across 6 categories -- momentum/returns (7 windows), volatility (6 indicators), volume (4 metrics), relative strength (beta, put/call), market breadth (5 cross-sectional), VIX (4 derivatives), FRED macroeconomic (7 series normalized 0-1), and cyclical time embeddings (6 sin/cos)
+- **FRED Integration**: Fetches 7 economic indicators via FRED API (10Y/2Y Treasury yields, CPI, unemployment, Fed Funds rate, industrial production, retail money market funds), caches to CSV, forward-fills missing dates
+- **Model Architecture** (`XGBoostInvestor.py`): `BaggingRegressor` wrapping 100 `XGBRegressor` estimators (learning_rate=0.05, max_depth=6, subsample=0.8), with `RobustScaler` for features and targets, plus `IsotonicRegression` calibration on the last 20% of training data
+- **Training Pipeline**: Collects 8 quarterly chunks of historical data, each with its own S&P 500 membership; prepares data by removing constant columns and non-finite rows; persists 5 pickle files (model, x_scaler, y_scaler, constant_cols, calibrator)
+- **Prediction Target**: Next-day forward return (`ret_1d` shifted by -1), predicting the percentage return one trading day ahead
+- **API Integration**: Two endpoints consume predictions -- `/api/getCurrentTickerConditions` returns raw features + XGBoost prediction, `/api/ticker-signal` feeds the prediction along with forecasts, pattern matches, and news into OpenAI for a BUY/SELL signal
+- **Backtesting** (`Simulator.py`): Runs year-by-year simulation selecting top-20 predicted stocks daily, tracks portfolio value; `Metrics.py` computes Sharpe, Sortino, Calmar ratios, drawdown, win rate, and exports to Excel + PNG charts
+
+---
+*Generated on 2026-03-26*

--- a/eval_scripts/batch_evaluate.py
+++ b/eval_scripts/batch_evaluate.py
@@ -31,6 +31,7 @@ from evaluate_weekly_insights import (
     _context_pct_changes,
     _context_symbols,
     _normalize_symbol,
+    geo_event_grounding,
     metric_hedge_language,
     metric_numerical_faithfulness,
     metric_output_completeness,
@@ -45,6 +46,7 @@ METRIC_KEYS = [
     "numerical_faithfulness",
     "hedge_language",
     "output_completeness",
+    "geo_grounding",
 ]
 
 RAGAS_KEYS = ["faithfulness", "answer_relevancy"]
@@ -110,6 +112,7 @@ def evaluate_one(base_url: str, end_date: str, num_tolerance: float,
 
     date_range = f"{insights.get('start', '?')} to {insights.get('end', '?')}"
 
+    source_headlines = [e.get("title", "") for e in events if e.get("title")]
     metrics = {
         "symbol_accuracy": metric_symbol_accuracy(output_text, ctx_symbols),
         "symbol_coverage": metric_symbol_coverage(output_text, ctx_symbols),
@@ -118,6 +121,7 @@ def evaluate_one(base_url: str, end_date: str, num_tolerance: float,
         ),
         "hedge_language": metric_hedge_language(event_impacts),
         "output_completeness": metric_output_completeness(market_insights, event_impacts),
+        "geo_grounding": geo_event_grounding(insights, source_headlines),
     }
 
     result = {
@@ -219,11 +223,11 @@ def print_summary(all_weeks: list[dict], has_ragas: bool = False) -> None:
     print("  Batch LLM Evaluation Summary")
     print("=" * 100)
 
-    header = f"  {'Week':<25} {'SymAcc':>7} {'SymCov':>7} {'NumFth':>7} {'Hedge':>7} {'Compl':>7}"
+    header = f"  {'Week':<25} {'SymAcc':>7} {'SymCov':>7} {'NumFth':>7} {'Hedge':>7} {'Compl':>7} {'GeoGr':>7}"
     if has_ragas:
         header += f" {'Faith':>7} {'Relev':>7}"
     print(header)
-    print("  " + "-" * (73 + (16 if has_ragas else 0)))
+    print("  " + "-" * (81 + (16 if has_ragas else 0)))
 
     for week in all_weeks:
         date_range = week["date_range"]
@@ -248,7 +252,7 @@ def print_summary(all_weeks: list[dict], has_ragas: bool = False) -> None:
         print(row)
 
     # Overall averages
-    print("  " + "-" * (73 + (16 if has_ragas else 0)))
+    print("  " + "-" * (81 + (16 if has_ragas else 0)))
     overall: dict[str, list[float]] = {k: [] for k in METRIC_KEYS + RAGAS_KEYS}
     for week in all_weeks:
         for key in METRIC_KEYS:

--- a/eval_scripts/evaluate_weekly_insights.py
+++ b/eval_scripts/evaluate_weekly_insights.py
@@ -41,6 +41,7 @@ import os
 import re
 import sys
 from datetime import datetime
+from functools import lru_cache
 from pathlib import Path
 from typing import Optional
 
@@ -208,6 +209,69 @@ def metric_output_completeness(
         "market_in_range_3_5": market_ok,
         "events_in_range_0_5": events_ok,
     }
+
+
+# ---------------------------------------------------------------------------
+# Geo event grounding (sentence-transformers, optional)
+# ---------------------------------------------------------------------------
+
+def _sbert_available() -> bool:
+    import importlib.util
+    return importlib.util.find_spec("sentence_transformers") is not None
+
+
+@lru_cache(maxsize=1)
+def _load_sbert():
+    from sentence_transformers import SentenceTransformer
+    return SentenceTransformer("all-MiniLM-L6-v2")
+
+
+def geo_event_grounding(
+    insights: dict,
+    source_headlines: list[str],
+    threshold: float = 0.75,
+) -> dict:
+    """Fraction of event_impacts bullets grounded in at least one source headline (cosine >= threshold)."""
+    event_impacts: list[str] = insights.get("event_impacts") or []
+    if not event_impacts:
+        return {"score": None, "note": "No event_impacts to evaluate"}
+    clean_headlines = [h for h in source_headlines if h]
+    if not clean_headlines:
+        return {"score": None, "note": "No source headlines provided"}
+    if not _sbert_available():
+        return {"score": None, "note": "sentence-transformers not installed"}
+
+    try:
+        import numpy as np
+        model = _load_sbert()
+        impact_embs = model.encode(event_impacts, normalize_embeddings=True)
+        headline_embs = model.encode(clean_headlines, normalize_embeddings=True)
+        sims = np.dot(impact_embs, headline_embs.T)  # (n_impacts, n_headlines)
+
+        details = []
+        grounded_count = 0
+        for i, bullet in enumerate(event_impacts):
+            max_sim = float(sims[i].max())
+            best_idx = int(sims[i].argmax())
+            is_grounded = max_sim >= threshold
+            if is_grounded:
+                grounded_count += 1
+            details.append({
+                "bullet": bullet,
+                "max_similarity": round(max_sim, 3),
+                "best_match": clean_headlines[best_idx][:120],
+                "grounded": is_grounded,
+            })
+
+        return {
+            "score": round(grounded_count / len(event_impacts), 3),
+            "grounded_count": grounded_count,
+            "total_bullets": len(event_impacts),
+            "threshold": threshold,
+            "details": details,
+        }
+    except Exception as exc:  # noqa: BLE001
+        return {"score": None, "note": f"sentence-transformers error: {exc}"}
 
 
 # ---------------------------------------------------------------------------
@@ -456,6 +520,18 @@ def print_report(report: dict) -> None:
     print(f"    Event impacts        : {oc['event_impacts_count']} bullets "
           f"({'OK' if oc['events_in_range_0_5'] else 'OUT OF RANGE'})")
 
+    geo = cm.get("geo_grounding")
+    if geo is not None:
+        print(f"  Geo Event Grounding     {_score_bar(geo.get('score'))}")
+        if geo.get("note"):
+            print(f"    Note                : {geo['note']}")
+        elif geo.get("details"):
+            ungrounded = [d for d in geo["details"] if not d.get("grounded")]
+            if ungrounded:
+                print("    Ungrounded bullets  :")
+                for d in ungrounded:
+                    print(f"      * {d['bullet'][:80]} (sim={d['max_similarity']:.3f})")
+
     ragas = report.get("ragas_metrics")
     if ragas:
         print()
@@ -565,6 +641,7 @@ def main() -> None:
     model = insights.get("model") or "unknown"
 
     # ── Custom metrics ───────────────────────────────────────────────────────
+    source_headlines = [e.get("title", "") for e in events if e.get("title")]
     custom_metrics = {
         "symbol_accuracy": metric_symbol_accuracy(output_text, ctx_symbols),
         "symbol_coverage": metric_symbol_coverage(output_text, ctx_symbols),
@@ -573,6 +650,7 @@ def main() -> None:
         ),
         "hedge_language": metric_hedge_language(event_impacts),
         "output_completeness": metric_output_completeness(market_insights, event_impacts),
+        "geo_grounding": geo_event_grounding(insights, source_headlines),
     }
 
     # ── Ragas metrics ────────────────────────────────────────────────────────

--- a/eval_scripts/experiment_info.txt
+++ b/eval_scripts/experiment_info.txt
@@ -1,0 +1,5 @@
+5 LLM models tested for 10 weeks, 5 trials over each week.
+
+You can use this data to generate all the charts, graphs, and table you desire :)
+
+It takes a long time to run otherwise.

--- a/eval_scripts/generate_backtest_charts.py
+++ b/eval_scripts/generate_backtest_charts.py
@@ -1,0 +1,841 @@
+"""
+generate_backtest_charts.py
+
+Generates aggregate result charts from the trading simulation backtest data in:
+  complete-backtest-results-20260402T004302Z-3-001/complete-backtest-results/
+
+Outputs 10 PNG charts to eval_scripts/charts/backtest/
+
+Usage:
+    python eval_scripts/generate_backtest_charts.py
+    python eval_scripts/generate_backtest_charts.py --data-dir path/to/complete-backtest-results
+"""
+
+import argparse
+import re
+import sys
+from glob import glob
+from pathlib import Path
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import matplotlib.ticker as mticker
+import numpy as np
+import pandas as pd
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+SCRIPT_DIR = Path(__file__).parent
+DEFAULT_DATA_DIR = (
+    SCRIPT_DIR
+    / "complete-backtest-results-20260402T004302Z-3-001"
+    / "complete-backtest-results"
+)
+
+NN_SP500_DIR = "simulation_results_naive_nn_sp500_2021-2025"
+NN_DOW_DIR = "simulation_results_naive_nn_sp500_train_dow_test_2021-2025"
+PATTERN_CSV = "Historical Patterns/pattern_recognition_backtesting.csv"
+
+MODEL_LABELS = {
+    NN_SP500_DIR: "NN (S&P 500)",
+    NN_DOW_DIR: "NN (DOW->S&P 500)",
+}
+
+OUT_DIR = SCRIPT_DIR / "charts" / "backtest"
+
+# ---------------------------------------------------------------------------
+# Styling
+# ---------------------------------------------------------------------------
+COLORS = {
+    NN_SP500_DIR: "#2196F3",
+    NN_DOW_DIR: "#FF9800",
+}
+GREEN = "#4CAF50"
+RED = "#F44336"
+GRID_ALPHA = 0.3
+
+plt.rcParams.update({
+    "font.family": "DejaVu Sans",
+    "axes.spines.top": False,
+    "axes.spines.right": False,
+    "axes.grid": True,
+    "grid.alpha": GRID_ALPHA,
+    "figure.dpi": 130,
+})
+
+# ---------------------------------------------------------------------------
+# S&P 500 baseline (SPY.US daily close from the project SQLite database)
+# ---------------------------------------------------------------------------
+DB_PATH = SCRIPT_DIR.parent / "data" / "stocks.db"
+
+
+def load_spy_baseline(start_date: str, end_date: str) -> pd.DataFrame:
+    """Load SPY daily closes from stocks.db, return DataFrame with date + cumul_roi columns.
+
+    cumul_roi = percentage return relative to the first trading day in the range.
+    """
+    import sqlite3
+    if not DB_PATH.exists():
+        return pd.DataFrame()
+    conn = sqlite3.connect(str(DB_PATH))
+    start_int = int(start_date.replace("-", ""))
+    end_int = int(end_date.replace("-", ""))
+    df = pd.read_sql(
+        "SELECT date, close FROM bars "
+        "WHERE symbol='SPY.US' AND timeframe='daily' "
+        "AND date >= ? AND date <= ? ORDER BY date",
+        conn, params=(start_int, end_int),
+    )
+    conn.close()
+    if df.empty:
+        return df
+    df["date"] = pd.to_datetime(df["date"].astype(str), format="%Y%m%d")
+    base = df["close"].iloc[0]
+    df["cumul_roi"] = (df["close"] / base - 1) * 100
+    return df
+
+
+def load_bah_returns(tickers: list, start_date: str, end_date: str) -> pd.DataFrame:
+    """Buy-and-hold return for each ticker over the date range, from stocks.db."""
+    import sqlite3
+    if not DB_PATH.exists():
+        return pd.DataFrame()
+    conn = sqlite3.connect(str(DB_PATH))
+    start_int = int(start_date.replace("-", ""))
+    end_int = int(end_date.replace("-", ""))
+    rows = []
+    for ticker in tickers:
+        df = pd.read_sql(
+            "SELECT date, close FROM bars "
+            "WHERE symbol=? AND timeframe='daily' "
+            "AND date >= ? AND date <= ? ORDER BY date",
+            conn, params=(ticker, start_int, end_int),
+        )
+        if len(df) < 10:
+            continue
+        ret = (df["close"].iloc[-1] / df["close"].iloc[0] - 1) * 100
+        rows.append({"ticker": ticker, "bah_return": ret})
+    conn.close()
+    return pd.DataFrame(rows)
+
+
+# ---------------------------------------------------------------------------
+# Parsers
+# ---------------------------------------------------------------------------
+
+def parse_output_md(path: Path) -> pd.DataFrame:
+    """Parse output.md into a DataFrame with one row per ticker.
+
+    The file alternates: separator / ticker-header / separator / data-block
+    so we use findall with a multi-line pattern across the whole text.
+    """
+    text = path.read_text(encoding="utf-8", errors="replace")
+    pattern = re.compile(
+        r"Simulation Results for (.+?):\s*-{10,}\s*"
+        r"Wallet:\s*([-\d.]+)\s*"
+        r"Total Invested:\s*([-\d.]+)\s*"
+        r"Earnings \(Sold\):\s*([-\d.]+)\s*"
+        r"Expense \(Bought\):\s*([-\d.]+)\s*"
+        r"Return on investment:\s*([-\d.]+)%\s*"
+        r"Number of investments:\s*(\d+)",
+        re.DOTALL,
+    )
+    records = []
+    for m in pattern.finditer(text):
+        records.append({
+            "ticker": m.group(1).strip(),
+            "wallet": float(m.group(2)),
+            "total_invested": float(m.group(3)),
+            "earnings": float(m.group(4)),
+            "expenses": float(m.group(5)),
+            "roi": float(m.group(6)),
+            "num_investments": int(m.group(7)),
+        })
+    return pd.DataFrame(records)
+
+
+def load_all_timeseries(sim_dir: Path) -> pd.DataFrame:
+    """Load all *_data.csv files and return last-entry-per-date-per-ticker combined frame."""
+    frames = []
+    for csv_path in sim_dir.glob("*_data.csv"):
+        df = pd.read_csv(csv_path, parse_dates=["date"])
+        ticker = re.search(r"simulation_results_(.+)_data", csv_path.name)
+        df["ticker"] = ticker.group(1) if ticker else csv_path.stem
+        # Keep last row per date (captures final state after all intraday trades)
+        df = df.groupby("date", as_index=False).last()
+        frames.append(df)
+    if not frames:
+        return pd.DataFrame()
+    return pd.concat(frames, ignore_index=True)
+
+
+def load_all_investments(sim_dir: Path) -> pd.DataFrame:
+    """Load all *_investments.csv files from a simulation directory."""
+    frames = []
+    for csv_path in sim_dir.glob("*_investments.csv"):
+        df = pd.read_csv(csv_path)
+        ticker = re.search(r"simulation_results_(.+)_investments", csv_path.name)
+        df["ticker"] = ticker.group(1) if ticker else csv_path.stem
+        frames.append(df)
+    if not frames:
+        return pd.DataFrame()
+    combined = pd.concat(frames, ignore_index=True)
+    combined["pnl_pct"] = (
+        (combined["selling_price"] - combined["purchase_price"])
+        / combined["purchase_price"]
+        * 100
+    )
+    combined["purchase_date"] = pd.to_datetime(combined["purchase_date"])
+    combined["selling_date"] = pd.to_datetime(combined["selling_date"])
+    combined["holding_days"] = (
+        combined["selling_date"] - combined["purchase_date"]
+    ).dt.days
+    return combined
+
+
+# ---------------------------------------------------------------------------
+# Section A — Per-Ticker Summary Charts
+# ---------------------------------------------------------------------------
+
+def chart_roi_distribution(summaries: dict, out_dir: Path):
+    """Overlaid histogram + KDE of final ROI% for both NN models."""
+    fig, ax = plt.subplots(figsize=(9, 5))
+    for key, df in summaries.items():
+        roi = df["roi"].dropna()
+        ax.hist(
+            roi, bins=25, alpha=0.45, color=COLORS[key],
+            label=MODEL_LABELS[key], edgecolor="white", linewidth=0.4,
+        )
+        # KDE overlay
+        from scipy.stats import gaussian_kde
+        kde = gaussian_kde(roi, bw_method=0.4)
+        xs = np.linspace(roi.min() - 5, roi.max() + 5, 300)
+        scale = len(roi) * (roi.max() - roi.min()) / 25
+        ax.plot(xs, kde(xs) * scale, color=COLORS[key], linewidth=2)
+
+    ax.axvline(0, color="black", linewidth=1.2, linestyle="--", label="Break-even (0%)")
+    ax.set_xlabel("Final ROI (%)")
+    ax.set_ylabel("Number of Tickers")
+    ax.set_title("ROI Distribution Across Tickers (2021–2025)")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(out_dir / "roi_distribution.png")
+    plt.close(fig)
+    print("  [OK] roi_distribution.png")
+
+
+def chart_wallet_distribution(summaries: dict, out_dir: Path):
+    """Boxplot of final wallet balance per model (started at $100)."""
+    fig, ax = plt.subplots(figsize=(7, 5))
+    data = [df["wallet"].dropna().values for df in summaries.values()]
+    labels = [MODEL_LABELS[k] for k in summaries]
+    bp = ax.boxplot(
+        data, labels=labels, patch_artist=True, notch=False,
+        medianprops={"color": "black", "linewidth": 1.5},
+    )
+    for patch, key in zip(bp["boxes"], summaries.keys()):
+        patch.set_facecolor(COLORS[key])
+        patch.set_alpha(0.7)
+    ax.axhline(100, color="black", linewidth=1, linestyle="--", label="Initial $100")
+    ax.set_ylabel("Final Wallet Balance ($)")
+    ax.set_title("Final Wallet Balance Distribution (Initial: $100)")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(out_dir / "wallet_distribution.png")
+    plt.close(fig)
+    print("  [OK] wallet_distribution.png")
+
+
+def chart_win_rate(summaries: dict, out_dir: Path):
+    """Grouped bar chart: % tickers with positive/negative ROI per model."""
+    labels = [MODEL_LABELS[k] for k in summaries]
+    win_pcts, lose_pcts = [], []
+    for df in summaries.values():
+        n = len(df)
+        win_pcts.append(100 * (df["roi"] > 0).sum() / n)
+        lose_pcts.append(100 * (df["roi"] <= 0).sum() / n)
+
+    x = np.arange(len(labels))
+    w = 0.35
+    fig, ax = plt.subplots(figsize=(7, 5))
+    bars_win = ax.bar(x - w / 2, win_pcts, w, label="Positive ROI", color=GREEN, alpha=0.85)
+    bars_lose = ax.bar(x + w / 2, lose_pcts, w, label="Negative ROI", color=RED, alpha=0.85)
+
+    for bar in list(bars_win) + list(bars_lose):
+        h = bar.get_height()
+        ax.text(
+            bar.get_x() + bar.get_width() / 2, h + 0.8,
+            f"{h:.1f}%", ha="center", va="bottom", fontsize=9,
+        )
+
+    ax.set_xticks(x)
+    ax.set_xticklabels(labels)
+    ax.set_ylabel("Percentage of Tickers (%)")
+    ax.set_title("Win Rate: Tickers with Positive vs Negative ROI")
+    ax.set_ylim(0, 110)
+    ax.yaxis.set_major_formatter(mticker.FormatStrFormatter("%.0f%%"))
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(out_dir / "win_rate.png")
+    plt.close(fig)
+    print("  [OK] win_rate.png")
+
+
+def chart_roi_vs_trades(summaries: dict, out_dir: Path):
+    """Scatter plot: num_investments vs ROI%, colored by model."""
+    fig, ax = plt.subplots(figsize=(9, 5))
+    for key, df in summaries.items():
+        ax.scatter(
+            df["num_investments"], df["roi"],
+            color=COLORS[key], label=MODEL_LABELS[key],
+            alpha=0.65, s=35, edgecolors="white", linewidths=0.3,
+        )
+    ax.axhline(0, color="black", linewidth=1, linestyle="--", alpha=0.5)
+    ax.set_xlabel("Number of Trades")
+    ax.set_ylabel("Final ROI (%)")
+    ax.set_title("ROI vs Number of Trades per Ticker")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(out_dir / "roi_vs_trades.png")
+    plt.close(fig)
+    print("  [OK] roi_vs_trades.png")
+
+
+# ---------------------------------------------------------------------------
+# Section B — Trade-Level Charts
+# ---------------------------------------------------------------------------
+
+def chart_trade_pnl_distribution(trades: dict, out_dir: Path):
+    """Histogram of per-trade P&L% for each model (two subplots)."""
+    keys = list(trades.keys())
+    fig, axes = plt.subplots(1, len(keys), figsize=(5 * len(keys), 5), sharey=False)
+    if len(keys) == 1:
+        axes = [axes]
+
+    for ax, key in zip(axes, keys):
+        pnl = trades[key]["pnl_pct"].dropna()
+        # Clip extreme outliers for display
+        p1, p99 = np.percentile(pnl, 1), np.percentile(pnl, 99)
+        pnl_clipped = pnl.clip(p1, p99)
+        ax.hist(pnl_clipped, bins=50, color=COLORS[key], alpha=0.8, edgecolor="white", linewidth=0.3)
+        ax.axvline(0, color="black", linewidth=1.2, linestyle="--")
+        mean_pnl = pnl.mean()
+        ax.axvline(mean_pnl, color=GREEN if mean_pnl >= 0 else RED,
+                   linewidth=1.5, linestyle=":", label=f"Mean: {mean_pnl:.2f}%")
+        ax.set_xlabel("Trade P&L (%)")
+        ax.set_ylabel("Count")
+        ax.set_title(MODEL_LABELS[key])
+        ax.legend(fontsize=8)
+
+    fig.suptitle("Per-Trade Profit/Loss Distribution (1st–99th percentile)", y=1.01)
+    fig.tight_layout()
+    fig.savefig(out_dir / "trade_pnl_distribution.png", bbox_inches="tight")
+    plt.close(fig)
+    print("  [OK] trade_pnl_distribution.png")
+
+
+def chart_holding_period(trades: dict, out_dir: Path):
+    """Overlaid histogram of holding period (days) per model."""
+    fig, ax = plt.subplots(figsize=(9, 5))
+    for key, df in trades.items():
+        hp = df["holding_days"].dropna()
+        hp = hp[hp >= 0]
+        ax.hist(
+            hp, bins=30, alpha=0.5, color=COLORS[key],
+            label=f"{MODEL_LABELS[key]} (median {hp.median():.0f}d)",
+            edgecolor="white", linewidth=0.3,
+        )
+    ax.set_xlabel("Holding Period (Days)")
+    ax.set_ylabel("Number of Trades")
+    ax.set_title("Trade Holding Period Distribution")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(out_dir / "holding_period.png")
+    plt.close(fig)
+    print("  [OK] holding_period.png")
+
+
+def chart_trade_win_rate(trades: dict, out_dir: Path):
+    """Bar chart: % of individual trades that were profitable per model."""
+    labels = [MODEL_LABELS[k] for k in trades]
+    win_pcts = [
+        100 * (df["pnl_pct"] > 0).sum() / len(df)
+        for df in trades.values()
+    ]
+    fig, ax = plt.subplots(figsize=(6, 5))
+    bars = ax.bar(labels, win_pcts, color=[COLORS[k] for k in trades], alpha=0.85, edgecolor="white")
+    for bar, pct in zip(bars, win_pcts):
+        ax.text(
+            bar.get_x() + bar.get_width() / 2, bar.get_height() + 0.5,
+            f"{pct:.1f}%", ha="center", va="bottom", fontsize=10,
+        )
+    ax.set_ylabel("Profitable Trades (%)")
+    ax.set_title("Individual Trade Win Rate")
+    ax.set_ylim(0, 100)
+    ax.yaxis.set_major_formatter(mticker.FormatStrFormatter("%.0f%%"))
+    fig.tight_layout()
+    fig.savefig(out_dir / "trade_win_rate.png")
+    plt.close(fig)
+    print("  [OK] trade_win_rate.png")
+
+
+# ---------------------------------------------------------------------------
+# Section C — Pattern Recognition Charts
+# ---------------------------------------------------------------------------
+
+def chart_pattern_directional_accuracy(df: pd.DataFrame, out_dir: Path):
+    """Bar chart of mean directional accuracy by interval."""
+    grouped = df.groupby("interval")["directional_accuracy"].mean().sort_index()
+    fig, ax = plt.subplots(figsize=(7, 5))
+    bars = ax.bar(
+        [f"{i} min" for i in grouped.index],
+        grouped.values * 100,
+        color="#9C27B0", alpha=0.8, edgecolor="white",
+    )
+    for bar, val in zip(bars, grouped.values):
+        ax.text(
+            bar.get_x() + bar.get_width() / 2, bar.get_height() + 0.4,
+            f"{val*100:.1f}%", ha="center", va="bottom", fontsize=9,
+        )
+    ax.set_xlabel("Candle Interval")
+    ax.set_ylabel("Mean Directional Accuracy (%)")
+    ax.set_title("Pattern Recognition: Directional Accuracy by Interval")
+    ax.set_ylim(0, 100)
+    ax.yaxis.set_major_formatter(mticker.FormatStrFormatter("%.0f%%"))
+    fig.tight_layout()
+    fig.savefig(out_dir / "pattern_directional_accuracy.png")
+    plt.close(fig)
+    print("  [OK] pattern_directional_accuracy.png")
+
+
+def chart_pattern_mse_comparison(df: pd.DataFrame, out_dir: Path):
+    """Paired bar chart of mean MSE vs baseline MSE by interval."""
+    grouped = df.groupby("interval")[["mse", "mse_baseline"]].mean().sort_index()
+    intervals = [f"{i} min" for i in grouped.index]
+    x = np.arange(len(intervals))
+    w = 0.35
+    fig, ax = plt.subplots(figsize=(8, 5))
+    ax.bar(x - w / 2, grouped["mse"] * 1e4, w, label="Model MSE (x10)",
+           color="#2196F3", alpha=0.8, edgecolor="white")
+    ax.bar(x + w / 2, grouped["mse_baseline"] * 1e4, w, label="Baseline MSE (x10)",
+           color="#FF9800", alpha=0.8, edgecolor="white")
+    ax.set_xticks(x)
+    ax.set_xticklabels(intervals)
+    ax.set_ylabel("MSE (x10)")
+    ax.set_title("Pattern Recognition: Model MSE vs Baseline MSE by Interval")
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(out_dir / "pattern_mse_comparison.png")
+    plt.close(fig)
+    print("  [OK] pattern_mse_comparison.png")
+
+
+def chart_pattern_accuracy_by_ticker(df: pd.DataFrame, out_dir: Path):
+    """Horizontal bar chart of mean directional accuracy per ticker, sorted."""
+    grouped = (
+        df.groupby("ticker")["directional_accuracy"]
+        .mean()
+        .sort_values(ascending=True)
+    )
+    # Limit to top/bottom for readability if too many tickers
+    if len(grouped) > 40:
+        grouped = pd.concat([grouped.head(20), grouped.tail(20)])
+
+    fig, ax = plt.subplots(figsize=(8, max(6, len(grouped) * 0.28)))
+    colors = [GREEN if v >= 0.5 else RED for v in grouped.values]
+    ax.barh(grouped.index, grouped.values * 100, color=colors, alpha=0.8, edgecolor="white", linewidth=0.3)
+    ax.axvline(50, color="black", linewidth=1, linestyle="--", label="50% (random)")
+    ax.set_xlabel("Mean Directional Accuracy (%)")
+    ax.set_title("Pattern Recognition: Directional Accuracy by Ticker")
+    ax.xaxis.set_major_formatter(mticker.FormatStrFormatter("%.0f%%"))
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(out_dir / "pattern_accuracy_by_ticker.png", bbox_inches="tight")
+    plt.close(fig)
+    print("  [OK] pattern_accuracy_by_ticker.png")
+
+
+# ---------------------------------------------------------------------------
+# Section D -- Time Series Charts
+# ---------------------------------------------------------------------------
+
+def _compute_annual_gain(ts: pd.DataFrame) -> pd.DataFrame:
+    """Helper: per-ticker annual ROI change from the strategy time series."""
+    ts = ts.copy()
+    ts["year"] = ts["date"].dt.year
+    year_end = ts.groupby(["year", "ticker"])["roi"].last()
+    year_start = ts.groupby(["year", "ticker"])["roi"].first()
+    annual_gain = (year_end - year_start).reset_index()
+    annual_gain.columns = ["year", "ticker", "annual_roi"]
+    return annual_gain
+
+
+def _spy_annual_returns(spy: pd.DataFrame) -> dict:
+    """Compute SPY annual price return (%) from daily close data."""
+    spy = spy.copy()
+    spy["year"] = spy["date"].dt.year
+    first = spy.groupby("year")["close"].first()
+    last = spy.groupby("year")["close"].last()
+    return ((last / first - 1) * 100).to_dict()
+
+
+def chart_roi_over_time(ts: pd.DataFrame, label: str, out_dir: Path, spy: pd.DataFrame):
+    """Single long-run chart: median cumulative ROI vs SPY cumulative return.
+
+    Both series start at 0% on the first trading day and represent
+    cumulative % return on an initial $100 investment.
+    The y-axis is fixed so both series are easy to compare.
+    """
+    ts = ts.copy()
+    ts["week"] = ts["date"].dt.to_period("W").dt.start_time
+    grouped = ts.groupby(["week", "ticker"])["roi"].last().reset_index()
+    weekly = grouped.groupby("week")["roi"].agg(
+        median="median", q25=lambda x: x.quantile(0.25), q75=lambda x: x.quantile(0.75)
+    ).reset_index()
+
+    fig, ax = plt.subplots(figsize=(12, 5))
+
+    # Strategy IQR band — clamp top to keep SPY on the same visible scale
+    q75_clipped = weekly["q75"].clip(upper=100)
+    ax.fill_between(weekly["week"], weekly["q25"], q75_clipped,
+                    alpha=0.22, color="#2196F3", label="Strategy 25th-75th percentile")
+    ax.plot(weekly["week"], weekly["median"], color="#2196F3", linewidth=2,
+            label="Strategy median cumulative return")
+
+    # SPY — same cumulative % return starting from the same date
+    if not spy.empty:
+        # Align SPY to the strategy's first week using exact date merge
+        spy_daily = spy.set_index("date")["cumul_roi"]
+        # Map each strategy week to the nearest available SPY trading day
+        strategy_dates = weekly["week"].values
+        spy_aligned = spy_daily.reindex(
+            spy_daily.index.union(pd.DatetimeIndex(strategy_dates))
+        ).interpolate(method="time").reindex(pd.DatetimeIndex(strategy_dates))
+        ax.plot(weekly["week"], spy_aligned.values, color="#FF9800", linewidth=2,
+                linestyle="--", label="SPY (S&P 500) cumulative return")
+
+    ax.axhline(0, color="black", linewidth=1, linestyle="--", alpha=0.4)
+
+    # Fix y-axis so both series are clearly readable
+    all_vals = list(weekly["median"])
+    if not spy.empty:
+        all_vals += list(spy_aligned.dropna())
+    ymax = max(100, max(all_vals) * 1.15)
+    ymin = min(-20, min(all_vals) * 1.15)
+    ax.set_ylim(ymin, ymax)
+
+    # Year bands
+    years = sorted(weekly["week"].dt.year.unique())
+    for i, yr in enumerate(years):
+        yr_data = weekly[weekly["week"].dt.year == yr]
+        if yr_data.empty:
+            continue
+        ax.axvspan(yr_data["week"].min(), yr_data["week"].max(),
+                   alpha=0.04 if i % 2 == 0 else 0, color="gray")
+        mid = yr_data["week"].min() + (yr_data["week"].max() - yr_data["week"].min()) / 2
+        ax.text(mid, ymin + 1, str(yr), ha="center", va="bottom",
+                fontsize=8, color="gray", alpha=0.7)
+
+    ax.set_xlabel("Date")
+    ax.set_ylabel("Cumulative Return on $100 (%)")
+    ax.set_title(f"Cumulative Return Over Time - {label} vs SPY")
+    ax.yaxis.set_major_formatter(mticker.FormatStrFormatter("%+.0f%%"))
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(out_dir / "roi_over_time.png")
+    plt.close(fig)
+    print("  [OK] roi_over_time.png")
+
+
+def chart_yearly_roi(ts: pd.DataFrame, label: str, out_dir: Path, spy: pd.DataFrame):
+    """Grouped bar chart: strategy mean annual return vs SPY annual return, same scale."""
+    annual_gain = _compute_annual_gain(ts)
+    summary = annual_gain.groupby("year")["annual_roi"].agg(
+        mean="mean", std="std", median="median"
+    ).reset_index()
+
+    spy_returns = _spy_annual_returns(spy) if not spy.empty else {}
+
+    x = np.arange(len(summary))
+    # Narrower bars when SPY is present so both fit side-by-side
+    w = 0.38 if spy_returns else 0.55
+
+    fig, ax = plt.subplots(figsize=(9, 5))
+
+    # Strategy bars
+    strat_colors = [GREEN if v >= 0 else RED for v in summary["mean"]]
+    strat_bars = ax.bar(x - w / 2, summary["mean"], w,
+                        yerr=summary["std"], capsize=5,
+                        color=strat_colors, alpha=0.8, edgecolor="white",
+                        error_kw={"elinewidth": 1.2, "ecolor": "gray"},
+                        label="Strategy (mean +/- std)")
+    for bar, mean_val, med_val in zip(strat_bars, summary["mean"], summary["median"]):
+        h = bar.get_height()
+        offset = 1.2 if h >= 0 else -3
+        ax.text(bar.get_x() + bar.get_width() / 2, h + offset,
+                f"mean {mean_val:+.1f}%\nmed {med_val:+.1f}%",
+                ha="center", va="bottom" if h >= 0 else "top", fontsize=7.5)
+
+    # SPY bars — same type and scale
+    if spy_returns:
+        spy_vals = [spy_returns.get(yr, np.nan) for yr in summary["year"]]
+        spy_colors = [GREEN if (not np.isnan(v) and v >= 0) else RED for v in spy_vals]
+        spy_bars = ax.bar(x + w / 2, spy_vals, w,
+                          color=spy_colors, alpha=0.5, edgecolor="#E65100",
+                          linewidth=1.2, label="SPY annual return")
+        for bar, val in zip(spy_bars, spy_vals):
+            if not np.isnan(val):
+                h = bar.get_height()
+                offset = 1.2 if h >= 0 else -3
+                ax.text(bar.get_x() + bar.get_width() / 2, h + offset,
+                        f"{val:+.1f}%", ha="center",
+                        va="bottom" if h >= 0 else "top", fontsize=7.5, color="#E65100")
+
+    ax.axhline(0, color="black", linewidth=1)
+    ax.set_xticks(x)
+    ax.set_xticklabels(summary["year"].astype(str))
+    ax.set_xlabel("Year")
+    ax.set_ylabel("Annual Return (%)")
+    ax.set_title(f"Annual Return per Year - {label} vs SPY")
+    ax.yaxis.set_major_formatter(mticker.FormatStrFormatter("%+.0f%%"))
+    ax.legend()
+    fig.tight_layout()
+    fig.savefig(out_dir / "yearly_roi_bar.png")
+    plt.close(fig)
+    print("  [OK] yearly_roi_bar.png")
+
+
+def chart_yearly_win_rate(ts: pd.DataFrame, label: str, out_dir: Path, spy: pd.DataFrame):
+    """Grouped bar chart: per year, % of tickers gaining vs losing.
+    SPY annual return shown as a text annotation above each year group.
+    """
+    annual_gain = _compute_annual_gain(ts)
+    summary = annual_gain.groupby("year")[["annual_roi"]].apply(
+        lambda g: pd.Series({
+            "win_pct": 100 * (g["annual_roi"] > 0).mean(),
+            "lose_pct": 100 * (g["annual_roi"] <= 0).mean(),
+        }),
+        include_groups=False,
+    ).reset_index()
+
+    spy_returns = _spy_annual_returns(spy) if not spy.empty else {}
+    years = summary["year"].astype(str).tolist()
+    x = np.arange(len(years))
+    w = 0.35
+
+    fig, ax = plt.subplots(figsize=(8, 5))
+    bars_win = ax.bar(x - w / 2, summary["win_pct"], w, label="Tickers gained", color=GREEN, alpha=0.85)
+    bars_lose = ax.bar(x + w / 2, summary["lose_pct"], w, label="Tickers lost/flat", color=RED, alpha=0.85)
+    for bar in list(bars_win) + list(bars_lose):
+        h = bar.get_height()
+        ax.text(bar.get_x() + bar.get_width() / 2, h + 0.8,
+                f"{h:.0f}%", ha="center", va="bottom", fontsize=8)
+
+    # Annotate SPY annual return above each year
+    if spy_returns:
+        for xi, yr in zip(x, summary["year"]):
+            val = spy_returns.get(yr, np.nan)
+            if not np.isnan(val):
+                color = "#2e7d32" if val >= 0 else "#b71c1c"
+                ax.text(xi, 107, f"SPY {val:+.1f}%", ha="center", va="bottom",
+                        fontsize=8, color=color, fontweight="bold")
+        # Add a dummy handle for the legend
+        from matplotlib.lines import Line2D
+        spy_handle = Line2D([0], [0], color="none", label="SPY annual return shown above bars")
+        handles, labels = ax.get_legend_handles_labels()
+        ax.legend(handles + [spy_handle], labels + ["SPY annual return shown above bars"],
+                  loc="lower right", fontsize=8)
+    else:
+        ax.legend()
+
+    ax.set_xticks(x)
+    ax.set_xticklabels(summary["year"].astype(str))
+    ax.set_ylabel("Percentage of Tickers (%)")
+    ax.set_ylim(0, 120)
+    ax.yaxis.set_major_formatter(mticker.FormatStrFormatter("%.0f%%"))
+    ax.set_title(f"Annual Win Rate by Year - {label} vs SPY")
+    fig.tight_layout()
+    fig.savefig(out_dir / "yearly_win_rate.png")
+    plt.close(fig)
+    print("  [OK] yearly_win_rate.png")
+
+
+def chart_strategy_vs_bah(summaries: dict, bah: pd.DataFrame, spy_cumul: float, out_dir: Path):
+    """Horizontal bar chart: strategy ROI vs buy-and-hold return, one row per ticker.
+
+    Tickers sorted by buy-and-hold return. Bars are paired so the two metrics
+    are directly comparable on the same scale.
+    """
+    key = next(iter(summaries))
+    strat = summaries[key][["ticker", "roi"]].copy()
+    merged = strat.merge(bah, on="ticker").sort_values("bah_return")
+
+    n = len(merged)
+    fig, ax = plt.subplots(figsize=(10, max(8, n * 0.28)))
+
+    y = np.arange(n)
+    h = 0.38
+
+    # Buy-and-hold bars
+    bah_colors = [GREEN if v >= 0 else RED for v in merged["bah_return"]]
+    ax.barh(y + h / 2, merged["bah_return"], h, color=bah_colors,
+            alpha=0.55, label="Buy-and-hold return")
+
+    # Strategy bars
+    strat_colors = [GREEN if v >= 0 else RED for v in merged["roi"]]
+    ax.barh(y - h / 2, merged["roi"], h, color=strat_colors,
+            alpha=0.85, label="Strategy ROI")
+
+    # SPY reference line
+    ax.axvline(spy_cumul, color="#FF9800", linewidth=1.5, linestyle="--",
+               label=f"SPY {spy_cumul:+.1f}%")
+    ax.axvline(0, color="black", linewidth=0.8, alpha=0.4)
+
+    ax.set_yticks(y)
+    ax.set_yticklabels(merged["ticker"].str.replace(".US", "", regex=False), fontsize=7)
+    ax.set_xlabel("Total Return over Backtest Period (%)")
+    ax.set_title(
+        f"Strategy ROI vs Buy-and-Hold per Ticker\n"
+        f"Strategy beats B&H on {(merged['roi'] > merged['bah_return']).sum()}/{n} tickers"
+    )
+    ax.xaxis.set_major_formatter(mticker.FormatStrFormatter("%+.0f%%"))
+    ax.legend(loc="lower right")
+    fig.tight_layout()
+    fig.savefig(out_dir / "strategy_vs_bah.png", bbox_inches="tight")
+    plt.close(fig)
+    print("  [OK] strategy_vs_bah.png")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate backtest result charts")
+    parser.add_argument(
+        "--data-dir", type=Path, default=DEFAULT_DATA_DIR,
+        help="Path to complete-backtest-results directory",
+    )
+    parser.add_argument(
+        "--out-dir", type=Path, default=OUT_DIR,
+        help="Output directory for charts",
+    )
+    args = parser.parse_args()
+
+    data_dir: Path = args.data_dir
+    out_dir: Path = args.out_dir
+
+    if not data_dir.exists():
+        print(f"ERROR: data directory not found: {data_dir}", file=sys.stderr)
+        sys.exit(1)
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    print(f"Output -> {out_dir}\n")
+
+    # ------------------------------------------------------------------
+    # Load NN simulation summaries
+    # ------------------------------------------------------------------
+    sim_dirs = {
+        NN_SP500_DIR: data_dir / NN_SP500_DIR,
+        NN_DOW_DIR: data_dir / NN_DOW_DIR,
+    }
+    summaries = {}
+    trades = {}
+    timeseries = {}
+    for key, sim_dir in sim_dirs.items():
+        if not sim_dir.exists():
+            print(f"  [!] Skipping missing directory: {sim_dir.name}")
+            continue
+        output_md = sim_dir / "output.md"
+        inv_csvs = list(sim_dir.glob("*_investments.csv"))
+        if not output_md.exists() and not inv_csvs:
+            print(f"  [!] Skipping empty directory: {sim_dir.name}")
+            continue
+        print(f"Loading {MODEL_LABELS[key]} ...")
+        if output_md.exists():
+            summaries[key] = parse_output_md(output_md)
+            print(f"  {len(summaries[key])} tickers parsed from output.md")
+        if inv_csvs:
+            trades[key] = load_all_investments(sim_dir)
+            print(f"  {len(trades[key])} trades loaded from investments CSVs")
+        data_csvs = list(sim_dir.glob("*_data.csv"))
+        if data_csvs:
+            timeseries[key] = load_all_timeseries(sim_dir)
+            print(f"  {len(timeseries[key])} time series rows loaded")
+
+    # ------------------------------------------------------------------
+    # Load SPY baseline from database
+    # ------------------------------------------------------------------
+    print("\nLoading SPY baseline from database ...")
+    spy_df = load_spy_baseline("2021-01-01", "2024-12-31")
+    if spy_df.empty:
+        print("  [!] SPY data not found in database - baseline will be omitted")
+    else:
+        print(f"  {len(spy_df)} daily SPY closes loaded "
+              f"({spy_df['date'].min().date()} to {spy_df['date'].max().date()})")
+
+    # ------------------------------------------------------------------
+    # Load buy-and-hold returns for all strategy tickers
+    # ------------------------------------------------------------------
+    bah_df = pd.DataFrame()
+    if summaries:
+        all_tickers = list(next(iter(summaries.values()))["ticker"])
+        print(f"\nLoading buy-and-hold returns for {len(all_tickers)} tickers ...")
+        bah_df = load_bah_returns(all_tickers, "2021-01-01", "2024-12-31")
+        print(f"  {len(bah_df)} tickers loaded from database")
+
+    # ------------------------------------------------------------------
+    # Load pattern recognition data
+    # ------------------------------------------------------------------
+    pattern_csv = data_dir / PATTERN_CSV
+    pattern_df = None
+    if pattern_csv.exists():
+        print(f"\nLoading pattern recognition data ...")
+        pattern_df = pd.read_csv(pattern_csv)
+        print(f"  {len(pattern_df)} rows, {pattern_df['ticker'].nunique()} tickers")
+    else:
+        print(f"  [!] Pattern CSV not found: {pattern_csv}")
+
+    # ------------------------------------------------------------------
+    # Generate charts
+    # ------------------------------------------------------------------
+    print("\nGenerating charts ...")
+
+    spy_cumul = float((spy_df["cumul_roi"].iloc[-1]) if not spy_df.empty else 0)
+
+    if summaries:
+        chart_roi_distribution(summaries, out_dir)
+        chart_wallet_distribution(summaries, out_dir)
+        chart_win_rate(summaries, out_dir)
+        chart_roi_vs_trades(summaries, out_dir)
+        if not bah_df.empty:
+            chart_strategy_vs_bah(summaries, bah_df, spy_cumul, out_dir)
+
+    if trades and any(len(t) > 0 for t in trades.values()):
+        nonempty = {k: v for k, v in trades.items() if len(v) > 0}
+        chart_trade_pnl_distribution(nonempty, out_dir)
+        chart_holding_period(nonempty, out_dir)
+        chart_trade_win_rate(nonempty, out_dir)
+
+    if pattern_df is not None:
+        chart_pattern_directional_accuracy(pattern_df, out_dir)
+        chart_pattern_mse_comparison(pattern_df, out_dir)
+        chart_pattern_accuracy_by_ticker(pattern_df, out_dir)
+
+    # Time-series charts (use first available model with data)
+    for key, ts_df in timeseries.items():
+        if ts_df.empty:
+            continue
+        label = MODEL_LABELS[key]
+        chart_roi_over_time(ts_df, label, out_dir, spy_df)
+        chart_yearly_roi(ts_df, label, out_dir, spy_df)
+        chart_yearly_win_rate(ts_df, label, out_dir, spy_df)
+        break  # Only one model has time series data
+
+    print(f"\nDone. Charts saved to: {out_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/eval_scripts/requirements.txt
+++ b/eval_scripts/requirements.txt
@@ -4,3 +4,4 @@ ragas>=0.2
 openai>=1.0
 matplotlib
 numpy
+sentence-transformers

--- a/eval_scripts/tests/test_geo_grounding.py
+++ b/eval_scripts/tests/test_geo_grounding.py
@@ -1,0 +1,162 @@
+"""Tests for geo_event_grounding in evaluate_weekly_insights."""
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from evaluate_weekly_insights import geo_event_grounding
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _mock_model(impact_vecs, headline_vecs):
+    """Create a mock SentenceTransformer returning controlled embeddings."""
+    mock = MagicMock()
+    call_count = {"n": 0}
+
+    def fake_encode(texts, normalize_embeddings=True):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            return np.array(impact_vecs, dtype=float)
+        return np.array(headline_vecs, dtype=float)
+
+    mock.encode.side_effect = fake_encode
+    return mock
+
+
+def _sbert_ctx(mock):
+    """Context manager: sbert available + _load_sbert returns mock."""
+    return (
+        patch("evaluate_weekly_insights._sbert_available", return_value=True),
+        patch("evaluate_weekly_insights._load_sbert", return_value=mock),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Edge cases (no model needed)
+# ---------------------------------------------------------------------------
+
+def test_empty_event_impacts():
+    result = geo_event_grounding({"event_impacts": []}, ["some headline"])
+    assert result["score"] is None
+    assert "No event_impacts" in result["note"]
+
+
+def test_missing_event_impacts_key():
+    result = geo_event_grounding({}, ["some headline"])
+    assert result["score"] is None
+
+
+def test_empty_source_headlines():
+    result = geo_event_grounding({"event_impacts": ["bullet"]}, [])
+    assert result["score"] is None
+    assert "No source headlines" in result["note"]
+
+
+def test_blank_source_headlines_filtered():
+    result = geo_event_grounding({"event_impacts": ["bullet"]}, ["", "  ", ""])
+    assert result["score"] is None
+    assert "No source headlines" in result["note"]
+
+
+def test_sbert_unavailable(monkeypatch):
+    monkeypatch.setattr("evaluate_weekly_insights._sbert_available", lambda: False)
+    result = geo_event_grounding({"event_impacts": ["bullet"]}, ["headline"])
+    assert result["score"] is None
+    assert "sentence-transformers" in result["note"]
+
+
+# ---------------------------------------------------------------------------
+# Grounding logic
+# ---------------------------------------------------------------------------
+
+def test_fully_grounded():
+    """Identical vectors -> cosine sim 1.0 -> all bullets grounded."""
+    mock = _mock_model([[1.0, 0.0]], [[1.0, 0.0]])
+    with _sbert_ctx(mock)[0], _sbert_ctx(mock)[1]:
+        result = geo_event_grounding({"event_impacts": ["rate hike impact"]}, ["Fed raises rates"])
+    assert result["score"] == 1.0
+    assert result["grounded_count"] == 1
+    assert result["details"][0]["grounded"] is True
+
+
+def test_not_grounded():
+    """Orthogonal vectors -> cosine sim 0.0 -> no bullets grounded."""
+    mock = _mock_model([[1.0, 0.0]], [[0.0, 1.0]])
+    with _sbert_ctx(mock)[0], _sbert_ctx(mock)[1]:
+        result = geo_event_grounding({"event_impacts": ["unrelated"]}, ["different headline"])
+    assert result["score"] == 0.0
+    assert result["grounded_count"] == 0
+    assert result["details"][0]["grounded"] is False
+
+
+def test_partial_grounding():
+    """First bullet grounded (sim=1.0), second not (sim=0.0)."""
+    mock = _mock_model([[1.0, 0.0], [0.0, 1.0]], [[1.0, 0.0]])
+    with _sbert_ctx(mock)[0], _sbert_ctx(mock)[1]:
+        result = geo_event_grounding(
+            {"event_impacts": ["grounded", "ungrounded"]},
+            ["matching headline"],
+        )
+    assert result["score"] == 0.5
+    assert result["grounded_count"] == 1
+    assert result["total_bullets"] == 2
+
+
+def test_threshold_boundary():
+    """Sim=0.8 passes threshold=0.75 but fails threshold=0.85."""
+    # impact=[1,0], headline=[0.8, 0.6] -> dot product = 0.8
+    def make_mock():
+        m = MagicMock()
+        calls = {"n": 0}
+
+        def enc(texts, normalize_embeddings=True):
+            calls["n"] += 1
+            return np.array([[1.0, 0.0]] * len(texts) if calls["n"] == 1 else [[0.8, 0.6]] * len(texts))
+
+        m.encode.side_effect = enc
+        return m
+
+    mock_pass = make_mock()
+    with _sbert_ctx(mock_pass)[0], _sbert_ctx(mock_pass)[1]:
+        result_pass = geo_event_grounding(
+            {"event_impacts": ["bullet"]}, ["headline"], threshold=0.75
+        )
+
+    mock_fail = make_mock()
+    with _sbert_ctx(mock_fail)[0], _sbert_ctx(mock_fail)[1]:
+        result_fail = geo_event_grounding(
+            {"event_impacts": ["bullet"]}, ["headline"], threshold=0.85
+        )
+
+    assert result_pass["details"][0]["grounded"] is True
+    assert result_fail["details"][0]["grounded"] is False
+
+
+def test_details_fields():
+    """Each detail entry has expected keys."""
+    mock = _mock_model([[1.0, 0.0]], [[1.0, 0.0]])
+    with _sbert_ctx(mock)[0], _sbert_ctx(mock)[1]:
+        result = geo_event_grounding({"event_impacts": ["bullet"]}, ["headline"])
+    assert "details" in result
+    d = result["details"][0]
+    assert "bullet" in d
+    assert "max_similarity" in d
+    assert "best_match" in d
+    assert "grounded" in d
+    assert result["threshold"] == 0.75
+
+
+def test_best_match_truncated():
+    """best_match is capped at 120 chars."""
+    long_headline = "x" * 200
+    mock = _mock_model([[1.0, 0.0]], [[1.0, 0.0]])
+    with _sbert_ctx(mock)[0], _sbert_ctx(mock)[1]:
+        result = geo_event_grounding({"event_impacts": ["bullet"]}, [long_headline])
+    assert len(result["details"][0]["best_match"]) <= 120

--- a/project_structure.md
+++ b/project_structure.md
@@ -1,0 +1,65 @@
+# Project: AI Stock Trading Platform
+
+AI-powered stock and crypto trading platform that uses LLMs for trading suggestions, market summaries, and weekly insights. Built as a COMS 599 creative component.
+
+## Architecture
+
+- **Frontend**: React 19 + TypeScript, Vite, MUI v7, served by Nginx on port 8080
+- **Backend**: FastAPI (Python), Uvicorn, runs on port 5000 internally
+- **Database**: SQLite with WAL mode at `/data/stocks.db` (~17GB), accessed via `fastapi/connector.py` (`get_connection(readonly=bool)`)
+- **Deployment**: Docker Compose with two services (`web`, `fastapi`), Nginx reverse proxies `/api/*` to FastAPI
+- **CI/CD**: GitLab CI at `.gitlab-ci.yml`
+
+## Backend Modules (`fastapi/`)
+
+| Module | Role |
+|---|---|
+| `main.py` | FastAPI app, all REST endpoints |
+| `weekly_dashboard.py` | OpenAI-powered weekly insights, NewsAPI integration, alerts, recommendations |
+| `forecasting.py` | Darts time series forecasting |
+| `pattern_recognition.py` | DTW pattern matching |
+| `fetch_prices.py` | Yahoo Finance price data updates |
+| `WeeklyMovers.py` | Weekly market movers calculation |
+| `scheduled_updates.py` | APScheduler background tasks |
+| `admin_jobs.py` | Admin job management |
+| `connector.py` | SQLite connection helper |
+| `symbol_collector.py` | Stock symbol management |
+| `xg_boost_investor/` | XGBoost ML model — `XGBoostInvestor.py`, `Features.py`, `Metrics.py`, `Simulator.py`, `PortfolioManager.py` |
+
+## API Endpoints (`fastapi/main.py`)
+
+- `/api/bars` — OHLCV price data
+- `/api/symbols` — Available stock symbols
+- `/api/weekly-movers` — Top weekly movers
+- `/api/weekly-insights` — LLM-generated market insights
+- `/api/weekly-alerts` — Price alerts
+- `/api/weekly-recommendation` — LLM purchase recommendations
+- `/api/ticker-signal` — Individual ticker analysis
+- `/api/getPatterns` — DTW pattern recognition
+- `/api/getForecasts` — Time series forecasts
+- `/api/getCurrentTickerConditions` — Current technical conditions
+- `/api/admin/*` — Admin endpoints (scheduler, jobs, DB info, updates)
+- `/api/health`, `/api/ready` — Health checks
+
+## Frontend (`stockai-web/`)
+
+**Routes** (`App.tsx`): `/` (Home), `/data` (DataSearch), `/dashboard`, `/admin`
+
+**Key directories**:
+- `src/components/charts/` — StockCharts, ForecastCharts, StockConditions, SimilarCharts, etc.
+- `src/services/` — `api.ts` (base client), `StockForecastService.ts`, `StockPatternService.ts`, `StockMarketConditionsService.ts`, `StockHistoryService.tsx`
+- `src/pages/` — HomePage, Dashboard, DataSearchPage, AdminPage
+
+## External Services
+
+- **OpenAI API** — Weekly insights text generation (`weekly_dashboard.py`)
+- **NewsAPI** — Market news for context
+- **Yahoo Finance** (`yfinance`) — Stock price data
+- **FRED API** — Economic indicators (referenced in commits)
+
+## Conventions
+
+- Backend caching uses thread locks + in-memory dicts with TTL (`CACHE_TTL_SECONDS = 86400`)
+- DB access: `get_connection(readonly=True)` for reads, `get_connection()` for writes
+- Environment variables via `.env` and `docker-compose.yml` (`OPENAI_API_KEY`, `NEWSAPI_KEY`, `DB_PATH`, etc.)
+- Frontend uses MUI theming with light/dark/system modes


### PR DESCRIPTION
## Summary

- Adds `geo_event_grounding()` to `evaluate_weekly_insights.py`: uses `all-MiniLM-L6-v2` (sentence-transformers) to measure how well each event impact bullet is semantically grounded in actual source headlines
- Cosine similarity threshold >= 0.75 to classify an impact as grounded; returns grounded_count / total_impacts
- Gracefully degrades if `sentence-transformers` is not installed (returns None)
- Integrates into `batch_evaluate.py`: new `geo_grounding` key in `METRIC_KEYS`, computed per trial, shown as `GeoGr` column in the summary table
- Adds `sentence-transformers` to `requirements.txt`
- Adds unit tests in `eval_scripts/tests/test_geo_grounding.py`
- Also includes: `generate_backtest_charts.py`, `experiment_info.txt`, `project_structure.md`, `CLAUDE.md`, and architecture diagrams in `docs/diagrams/`

## Test plan

- [ ] Run `python eval_scripts/tests/test_geo_grounding.py` -- all tests pass
- [ ] Run `python eval_scripts/evaluate_weekly_insights.py` for a single week -- `geo_grounding` score appears in report output
- [ ] Run `python eval_scripts/batch_evaluate.py --weeks 1` -- `GeoGr` column present in summary table
- [ ] Confirm graceful degradation: temporarily uninstall `sentence-transformers`, re-run -- metric returns None without crashing

Closes #24