### PR TITLE
feat(#34): replace NewsAPI with NewsData.io for public-deploy licensing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,27 @@
+# Copy this file to .env and fill in real values.
+# Loaded automatically by docker-compose.yml at container start.
+
+# --- Required ---
+
+# OpenAI API key — used for weekly insights, recommendations, and ticker signals.
+# https://platform.openai.com/api-keys
+OPENAI_API_KEY=
+
+# NewsData.io API key — used for market and per-symbol news.
+# Free tier: 200 requests/day, 10 articles/request, last ~48h.
+# https://newsdata.io/register
+NEWSDATA_API_KEY=
+
+# --- Optional ---
+
+# Override the local directory mounted to /data in the fastapi container.
+# Defaults to ./data if unset.
+# DB_DIR=./data
+
+# Custom NewsData query and page size (defaults are fine for most use cases).
+# NEWSDATA_QUERY=stock market OR stocks OR equities OR earnings OR inflation OR "Federal Reserve" OR rates OR oil OR geopolitics
+# NEWSDATA_PAGE_SIZE=10
+
+# Manual events feed — overrides NewsData.io if set.
+# MARKET_EVENTS_JSON=[{"title":"Example","date":"2026-06-01","source":"manual","url":"https://example.com"}]
+# MARKET_EVENTS_URL=https://example.com/events.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,6 +16,6 @@ services:
       - SCHEDULED_UPDATE_ENABLED=true
       - SCHEDULED_UPDATE_TIMEZONE=America/Chicago
       - OPENAI_API_KEY=${OPENAI_API_KEY}
-      - NEWSAPI_KEY=${NEWSAPI_KEY}
+      - NEWSDATA_API_KEY=${NEWSDATA_API_KEY}
     volumes:
       - ${DB_DIR:-./data}:/data # fall back to ./data path locally

--- a/fastapi/weekly_dashboard.py
+++ b/fastapi/weekly_dashboard.py
@@ -248,8 +248,18 @@ def _fetch_newsdata(query: str, page_size: int) -> tuple[list[dict], str | None]
         response = requests.get(NEWSDATA_ENDPOINT, params=params, timeout=10)
         response.raise_for_status()
         data = response.json()
-    except requests.RequestException:
-        return [], "Failed to load NewsData.io events."
+    except requests.exceptions.HTTPError as exc:
+        status = exc.response.status_code if exc.response is not None else "?"
+        body = ""
+        try:
+            body = exc.response.json().get("results", {}).get("message") or exc.response.text[:120]
+        except Exception:
+            pass
+        LOGGER.error("NewsData.io HTTP %s: %s", status, body)
+        return [], f"NewsData.io returned HTTP {status}: {body}"
+    except requests.RequestException as exc:
+        LOGGER.error("NewsData.io request failed: %s", exc)
+        return [], f"Failed to load NewsData.io events: {exc}"
     except json.JSONDecodeError:
         return [], "NewsData.io did not return JSON."
 

--- a/fastapi/weekly_dashboard.py
+++ b/fastapi/weekly_dashboard.py
@@ -38,10 +38,7 @@ INSIGHTS_CACHE: dict[str, object] = {
 CORE_SYMBOLS_DEFAULT = "NVDA,AAPL,MSFT,AMZN,GOOGL,META,TSLA,AMD,NFLX,JPM"
 BENCHMARK_SYMBOLS_DEFAULT = "SPY,QQQ,DIA,IWM"
 NEWSDATA_ENDPOINT = "https://newsdata.io/api/1/latest"
-NEWSDATA_DEFAULT_QUERY = (
-    "stock market OR stocks OR equities OR earnings OR inflation OR "
-    "\"Federal Reserve\" OR rates OR oil OR geopolitics"
-)
+NEWSDATA_DEFAULT_QUERY = "stocks OR earnings OR inflation OR Federal Reserve OR oil OR geopolitics"
 NEWSDATA_MAX_PAGE_SIZE = 10
 
 

--- a/fastapi/weekly_dashboard.py
+++ b/fastapi/weekly_dashboard.py
@@ -37,11 +37,12 @@ INSIGHTS_CACHE: dict[str, object] = {
 
 CORE_SYMBOLS_DEFAULT = "NVDA,AAPL,MSFT,AMZN,GOOGL,META,TSLA,AMD,NFLX,JPM"
 BENCHMARK_SYMBOLS_DEFAULT = "SPY,QQQ,DIA,IWM"
-NEWSAPI_ENDPOINT = "https://newsapi.org/v2/everything"
-NEWSAPI_DEFAULT_QUERY = (
+NEWSDATA_ENDPOINT = "https://newsdata.io/api/1/latest"
+NEWSDATA_DEFAULT_QUERY = (
     "stock market OR stocks OR equities OR earnings OR inflation OR "
-    "Federal Reserve OR rates OR oil OR geopolitics"
+    "\"Federal Reserve\" OR rates OR oil OR geopolitics"
 )
+NEWSDATA_MAX_PAGE_SIZE = 10
 
 
 def _ensure_list(value) -> list[str]:
@@ -232,6 +233,47 @@ def _normalize_event(event: dict) -> dict:
     }
 
 
+def _fetch_newsdata(query: str, page_size: int) -> tuple[list[dict], str | None]:
+    api_key = os.getenv("NEWSDATA_API_KEY") or os.getenv("NEWSDATA_KEY")
+    if not api_key:
+        return [], "NEWSDATA_API_KEY is not configured."
+
+    params = {
+        "apikey": api_key,
+        "q": query,
+        "language": "en",
+        "size": max(1, min(page_size, NEWSDATA_MAX_PAGE_SIZE)),
+    }
+    try:
+        response = requests.get(NEWSDATA_ENDPOINT, params=params, timeout=10)
+        response.raise_for_status()
+        data = response.json()
+    except requests.RequestException:
+        return [], "Failed to load NewsData.io events."
+    except json.JSONDecodeError:
+        return [], "NewsData.io did not return JSON."
+
+    results = data.get("results", []) if isinstance(data, dict) else []
+    events: list[dict] = []
+    for item in results:
+        if not isinstance(item, dict):
+            continue
+        title = str(item.get("title") or "").strip()
+        if not title:
+            continue
+        source = item.get("source_id") or item.get("source_name")
+        events.append(
+            {
+                "title": title,
+                "date": item.get("pubDate"),
+                "source": source,
+                "url": item.get("link"),
+                "image_url": item.get("image_url"),
+            }
+        )
+    return events, None
+
+
 def _load_events(start_date, end_date) -> tuple[list[dict], str | None, list[str]]:
     raw_json = os.getenv("MARKET_EVENTS_JSON")
     if raw_json:
@@ -255,51 +297,14 @@ def _load_events(start_date, end_date) -> tuple[list[dict], str | None, list[str
         except json.JSONDecodeError:
             return [], "MARKET_EVENTS_JSON is not valid JSON.", []
 
-    newsapi_key = os.getenv("NEWSAPI_KEY") or os.getenv("NEWSAPI_API_KEY")
-    if newsapi_key:
-        query = os.getenv("NEWSAPI_QUERY", NEWSAPI_DEFAULT_QUERY)
+    if os.getenv("NEWSDATA_API_KEY") or os.getenv("NEWSDATA_KEY"):
+        query = os.getenv("NEWSDATA_QUERY", NEWSDATA_DEFAULT_QUERY)
         try:
-            page_size = int(os.getenv("NEWSAPI_PAGE_SIZE", "12"))
+            page_size = int(os.getenv("NEWSDATA_PAGE_SIZE", "10"))
         except ValueError:
-            page_size = 12
-        params = {
-            "q": query,
-            "from": start_date.isoformat(),
-            "to": end_date.isoformat(),
-            "language": "en",
-            "sortBy": "relevancy",
-            "pageSize": max(1, min(page_size, 50)),
-        }
-        try:
-            response = requests.get(
-                NEWSAPI_ENDPOINT,
-                params=params,
-                headers={"X-Api-Key": newsapi_key},
-                timeout=10,
-            )
-            response.raise_for_status()
-            data = response.json()
-        except requests.RequestException:
-            return [], "Failed to load NewsAPI events.", ["newsapi.org"]
-        except json.JSONDecodeError:
-            return [], "NewsAPI did not return JSON.", ["newsapi.org"]
-
-        articles = data.get("articles", []) if isinstance(data, dict) else []
-        events = []
-        for article in articles:
-            if not isinstance(article, dict):
-                continue
-            events.append(
-                {
-                    "title": str(article.get("title") or "").strip(),
-                    "date": article.get("publishedAt"),
-                    "source": (article.get("source") or {}).get("name"),
-                    "url": article.get("url"),
-                    "image_url": article.get("urlToImage"),
-                }
-            )
-        events = [event for event in events if event["title"]]
-        return events, None, ["newsapi.org"]
+            page_size = 10
+        events, error = _fetch_newsdata(query, page_size)
+        return events, error, ["newsdata.io"]
 
     url = os.getenv("MARKET_EVENTS_URL")
     if not url:
@@ -939,31 +944,17 @@ def build_ticker_signal(symbol: str) -> dict:
     except Exception as exc:
         LOGGER.warning("Market news load failed: %s", exc)
 
-    newsapi_key = os.getenv("NEWSAPI_KEY") or os.getenv("NEWSAPI_API_KEY")
-    if newsapi_key:
+    if os.getenv("NEWSDATA_API_KEY") or os.getenv("NEWSDATA_KEY"):
         try:
-            response = requests.get(
-                NEWSAPI_ENDPOINT,
-                params={
-                    "q": f"{symbol} stock",
-                    "from": week_ago.isoformat(),
-                    "to": today.isoformat(),
-                    "language": "en",
-                    "sortBy": "relevancy",
-                    "pageSize": 5,
-                },
-                headers={"X-Api-Key": newsapi_key},
-                timeout=10,
-            )
-            response.raise_for_status()
-            articles = response.json().get("articles", [])
+            articles, fetch_error = _fetch_newsdata(f"{symbol} stock", 5)
+            if fetch_error:
+                LOGGER.warning("Symbol news fetch failed for %s: %s", symbol, fetch_error)
             for article in articles:
-                if isinstance(article, dict) and article.get("title"):
-                    symbol_news.append({
-                        "title": str(article["title"]).strip(),
-                        "date": article.get("publishedAt"),
-                        "source": (article.get("source") or {}).get("name"),
-                    })
+                symbol_news.append({
+                    "title": article["title"],
+                    "date": article.get("date"),
+                    "source": article.get("source"),
+                })
         except Exception as exc:
             LOGGER.warning("Symbol news fetch failed for %s: %s", symbol, exc)
 

--- a/stockai-web/src/components/StockSearch.tsx
+++ b/stockai-web/src/components/StockSearch.tsx
@@ -66,11 +66,19 @@ export default function StockSearch(props: StockSearchProps) {
         setSearchValue("")
         props.setBars([])
         props.setSymbol("")
-        const response = await fetchStockHistory(symbol, "daily")
-        props.setBars(response.results)
-        props.setSymbol(response.results[0].symbol)
-        setLoading(false)
-
+        try {
+            const response = await fetchStockHistory(symbol, "daily")
+            if (!response.results || response.results.length === 0) {
+                console.error(`No bars returned for symbol: ${symbol}`)
+                return
+            }
+            props.setBars(response.results)
+            props.setSymbol(response.results[0].symbol)
+        } catch (err) {
+            console.error("Failed to load symbol data:", err)
+        } finally {
+            setLoading(false)
+        }
     }
 
 

--- a/stockai-web/src/components/charts/ForecastCharts.tsx
+++ b/stockai-web/src/components/charts/ForecastCharts.tsx
@@ -4,6 +4,7 @@ import {
   Accordion,
   AccordionDetails,
   AccordionSummary,
+  Alert,
   Card,
   CardContent,
   Typography,
@@ -19,28 +20,20 @@ interface ForecastChartsProps {
   symbol: string;
 }
 
-async function getForecasts(
-  symbol: string,
-  forecastLength: number,
-  setLoading: (data: boolean) => void,
-) {
-  setLoading(true);
-  const response = await fetchStockForecasts(symbol, "daily", forecastLength);
-  const forecasts: StockForecast[] = response["results"];
-  setLoading(false);
-  return forecasts;
-}
-
 export function ForecastCharts(props: ForecastChartsProps) {
   const [loading, setLoading] = useState(false);
   const [forecasts, setForecasts] = useState<StockForecast[]>([]);
+  const [error, setError] = useState<string | null>(null);
   const forecastLength = 10;
 
   useEffect(() => {
     if (props.symbol === "") return;
-    getForecasts(props.symbol, forecastLength, setLoading).then((response) =>
-      setForecasts(response),
-    );
+    setLoading(true);
+    setError(null);
+    fetchStockForecasts(props.symbol, "daily", forecastLength)
+      .then((response) => setForecasts(response["results"] ?? []))
+      .catch((err: Error) => setError(err.message))
+      .finally(() => setLoading(false));
   }, [props.symbol]);
 
   if (props.symbol === "") return <></>;
@@ -52,6 +45,19 @@ export function ForecastCharts(props: ForecastChartsProps) {
           <Stack direction="row" alignItems="center" spacing={2}>
             <Typography variant="h4">Stock Price Forecasting</Typography>
             <GradientCircularProgress />
+          </Stack>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card sx={{ borderRadius: 3 }}>
+        <CardContent>
+          <Stack direction="row" alignItems="center" spacing={2}>
+            <Typography variant="h4">Stock Price Forecasting</Typography>
+            <Alert severity="error">Failed to load forecasts: {error}</Alert>
           </Stack>
         </CardContent>
       </Card>

--- a/stockai-web/src/components/charts/SimilarCharts.tsx
+++ b/stockai-web/src/components/charts/SimilarCharts.tsx
@@ -1,6 +1,6 @@
 import {
     Accordion, AccordionDetails,
-    AccordionSummary, Button, Card, CardContent,
+    AccordionSummary, Alert, Button, Card, CardContent,
     Container,
     Paper,
     Table, TableBody,
@@ -38,33 +38,31 @@ function getStartDate(bars: Bar[], trendLength: number){
     startTrendDate.setDate(endTrendDate.getDate() - trendLength)
     return startTrendDate
 }
-async function getPatterns(symbol:string, trendLength: number, setLoading: (data: boolean) => void) {
-    setLoading(true)
-    const response = await fetchStockPatterns(symbol, "daily", trendLength)
-    const patterns: StockPattern[] = response['results']
-    const recentPatterns: StockPattern[] = []
-    patterns.forEach((pattern) => {
-        const tenYearsAgo = new Date()
-        tenYearsAgo.setDate(tenYearsAgo.getDate() - 365 * 10)
-        if(getDateFromYYYYMMDD(pattern.starting_date.toString()) >= tenYearsAgo){
-            recentPatterns.push(pattern)
-        }
-    })
-    setLoading(false)
-    return recentPatterns
-}
 
 function SimilarCharts(props: SimilarChartsProps){
     const [ patterns, setPatterns ] = useState<StockPattern[]>(null as unknown as StockPattern[])
     const [ loading, setLoading ] = useState(false)
     const [ patternPageIndex, setPatternPageIndex ] = useState(0)
+    const [ error, setError ] = useState<string | null>(null)
     const patternsPerPage = 10
     const trendLength = 7
     useEffect(() => {
         if(props.symbol === ""){
             return
         }
-        getPatterns(props.symbol, trendLength, setLoading).then((response) => setPatterns(response))
+        setError(null)
+        setLoading(true)
+        fetchStockPatterns(props.symbol, "daily", trendLength)
+            .then((response) => {
+                const all: StockPattern[] = response['results'] ?? []
+                const tenYearsAgo = new Date()
+                tenYearsAgo.setDate(tenYearsAgo.getDate() - 365 * 10)
+                setPatterns(all.filter(p =>
+                    getDateFromYYYYMMDD(p.starting_date.toString()) >= tenYearsAgo
+                ))
+            })
+            .catch((err: Error) => setError(err.message))
+            .finally(() => setLoading(false))
     }, [props.symbol])
     if(props.symbol=== ""){
         return <></>
@@ -82,6 +80,18 @@ function SimilarCharts(props: SimilarChartsProps){
                     <Stack direction="row" alignItems="center" spacing={2}>
                         <Typography variant="h4">Historical Trend Analysis</Typography>
                         <GradientCircularProgress />
+                    </Stack>
+                </CardContent>
+            </Card>
+        );
+    }
+    if (error) {
+        return (
+            <Card sx={{ borderRadius: 3 }}>
+                <CardContent>
+                    <Stack direction="row" alignItems="center" spacing={2}>
+                        <Typography variant="h4">Historical Trend Analysis</Typography>
+                        <Alert severity="error">Failed to load patterns: {error}</Alert>
                     </Stack>
                 </CardContent>
             </Card>


### PR DESCRIPTION
Closes #34
Refs #17, #27

## Summary
- Replaces NewsAPI (free tier disallows public deploy) with NewsData.io across the
  two call sites in `fastapi/weekly_dashboard.py`.
- Preserves the `MarketEvent` shape consumed by `WeeklyWorldEventsCard`
  (`title`/`date`/`source`/`url`/`image_url`).
- Renames env var `NEWSAPI_KEY` -> `NEWSDATA_API_KEY` in `docker-compose.yml`.
- `MARKET_EVENTS_JSON` and `MARKET_EVENTS_URL` fallbacks left untouched.

## Field mapping (NewsAPI -> NewsData.io)
| NewsAPI | NewsData.io |
|---|---|
| `articles[]` | `results[]` |
| `title` | `title` |
| `url` | `link` |
| `urlToImage` | `image_url` |
| `publishedAt` | `pubDate` |
| `source.name` | `source_id` |
| header `X-Api-Key` | query `apikey=` |
| `/v2/everything` | `/api/1/latest` |

NewsData.io free tier returns the last ~48h with no date filter. Historical
`end_date` calls in `build_weekly_insights` now return the latest available
news (instead of an empty list) — acceptable for current research workflow.

## Out of scope
- GDELT integration for historical archive / geopolitical features (#19, #23, #24)
  will land as a follow-up.
- Paid NewsData.io archive tier.

## Required secrets for VPS deploy (PR #27)
`NEWSAPI_KEY` is replaced by `NEWSDATA_API_KEY`. The deploy thread on #17 / PR
#27 should be updated to reflect the new secret name.

## Test plan
- [ ] Set `NEWSDATA_API_KEY` locally, hit `GET /api/weekly-insights`, confirm
      `events[]` populated with title/url/image and `sources: ["newsdata.io"]`.
- [ ] Open the frontend weekly view, confirm thumbnails and "Read source" links
      render and open the correct articles.
- [ ] Hit `GET /api/ticker-signal?symbol=NVDA`, confirm non-empty signal with
      no upstream errors in logs.
- [ ] Unset `NEWSDATA_API_KEY`, set `MARKET_EVENTS_JSON` to a small array,
      confirm events render from the manual feed.
- [ ] Unset both, confirm UI shows the `events_note` string.
- [ ] `grep -ri "newsapi" .` returns no matches in tracked code (verified).